### PR TITLE
Added batch matrix multiplication, solving triangular system and LU decomposition.

### DIFF
--- a/scikits/cuda/cublas.py
+++ b/scikits/cuda/cublas.py
@@ -4837,20 +4837,24 @@ def cublasZher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 ### BLAS-like extension routines ###
 
 # SDGMM, DDGMM, CDGMM, ZDGMM
-def v5req(f):
+class vreq(object):
     """
-    Decorator to replace function with a placeholder unless cublas version is greater than 5.0. Placeholder raises an exception. 
+    Decorator to replace function with a placeholder unless cublas version is greater than v. Placeholder raises an exception. 
     """
-    def f_new(*args,**kwargs):
-        raise NotImplementedError('CUBLAS 5.0 required')
-    f_new.__doc__ = f.__doc__
+    def __init__(self,v):
+        self.vs = str(v)
+        self.vi = int(v*1000)
 
-    if _cublas_version >= 5000:
-        return f
-    else:
-        return f_new
-    
-    
+    def __call__(self,f):
+        def f_new(*args,**kwargs):
+            raise NotImplementedError('CUBLAS '+self.vs+' required')
+        f_new.__doc__ = f.__doc__
+
+        if _cublas_version >= self.vi:
+            return f
+        else:
+            return f_new
+        
      
 _libcublas.cublasSdgmm.restype = int
 _libcublas.cublasSdgmm.argtypes = [ctypes.c_int,
@@ -4864,7 +4868,7 @@ _libcublas.cublasSdgmm.argtypes = [ctypes.c_int,
                                    ctypes.c_void_p,
                                    ctypes.c_int]
 
-@v5req
+@vreq(5.0)
 def cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc):
     """
     Matrix-diagonal matrix product for real general matrix.
@@ -4891,7 +4895,7 @@ _libcublas.cublasDdgmm.argtypes = [ctypes.c_int,
                                    ctypes.c_void_p,
                                    ctypes.c_int]
 
-@v5req
+@vreq(5)
 def cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc):
     """
     Matrix-diagonal matrix product for real general matrix.
@@ -4919,7 +4923,7 @@ _libcublas.cublasCdgmm.argtypes = [ctypes.c_int,
                                    ctypes.c_void_p,
                                    ctypes.c_int]
 
-@v5req
+@vreq(5)
 def cublasCdgmm(mode, m, n, A, lda, x, incx, C, ldc):
     """
     Matrix-diagonal matrix product for complex general matrix.
@@ -4946,7 +4950,7 @@ _libcublas.cublasZdgmm.argtypes = [ctypes.c_int,
                                    ctypes.c_void_p,
                                    ctypes.c_int]
 
-@v5req
+@vreq(5)
 def cublasZdgmm(mode, m, n, A, lda, x, incx, C, ldc):
     """
     Matrix-diagonal matrix product for complex general matrix.
@@ -4960,10 +4964,106 @@ def cublasZdgmm(mode, m, n, A, lda, x, incx, C, ldc):
                                     int(x), incx,
                                     int(C), ldc)
     cublasCheckStatus(status)        
-
-
     
+### Batched routines ###
 
+# SgemmBatched, 
+_libcublas.cublasSgemmBatched.restype = int
+_libcublas.cublasSgemmBatched.argtypes = [ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_int]
+@vreq(4.1)
+def cublasSgemmBatched(handle, transa, transb, m, n, k, 
+                alpha, A, lda, B, ldb, beta, C, ldc, batchCount):
+    """
+    Matrix-matrix product for arrays of real general matrices.
+
+    """
+
+    status = _libcublas.cublasSgemmBatched(handle,
+                                       _CUBLAS_OP[transa],
+                                       _CUBLAS_OP[transb], m, n, k, 
+                                       ctypes.byref(ctypes.c_float(alpha)),
+                                       int(A), lda, int(B), ldb,
+                                       ctypes.byref(ctypes.c_float(beta)),
+                                       int(C), ldc, batchCount)
+    cublasCheckStatus(status)
+
+# StrsmBatched
+
+_libcublas.cublasStrsmBatched.restype = int
+_libcublas.cublasStrsmBatched.argtypes = [ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_int]
+@vreq(5.0)
+def cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, 
+                    A, lda, B, ldb, batchCount):
+    """
+    This function solves an array of triangular linear systems with multiple right-hand-sides
+
+    """
+
+    status = _libcublas.cublasStrsmBatched(handle,
+                                       _CUBLAS_SIDE_MODE[side],
+                                       _CUBLAS_FILL_MODE[uplo],
+                                       _CUBLAS_OP[trans],
+                                       _CUBLAS_DIAG[diag],
+                                       m, n, 
+                                       ctypes.byref(ctypes.c_float(alpha)),
+                                       int(A), lda, int(B), ldb,
+                                       batchCount)
+    cublasCheckStatus(status)
+
+
+# getrfBatched
+
+_libcublas.cublasSgetrfBatched.restype = int
+_libcublas.cublasSgetrfBatched.argtypes = [ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int]
+@vreq(5.0)
+def cublasSgetrfBatched(handle, n, A, lda, P, info, batchSize):
+    """
+    This function performs the LU factorization of an array of n x n matrices.
+    """
+
+    status = _libcublas.cublasSgetrfBatched(handle, n,
+                                       int(A), lda, int(P), 
+                                       int(info),batchSize
+                                       )
+    cublasCheckStatus(status)
+
+
+
+
+
+ 
 if __name__ == "__main__":
     import doctest
     doctest.testmod()


### PR DESCRIPTION
Hi,

First let me thank you for your work making the CUDA libraries usable form python. With these my code will work 100-1000 fold faster and hopefully help me earn my PhD sooner. 

My use case for CUDA is a bit atypical. Most libraries I've seen focus on processing large matrices. What I need to do is run the same program on thousands on small matrices in parallel. Luckily, cublas v5.0 added the routines I need (listed below) so I have added wrappers to those in scikits/cuda/cublas.py.

http://docs.nvidia.com/cuda/cublas/index.html#unique_1756671368
http://docs.nvidia.com/cuda/cublas/index.html#unique_1732840107
http://docs.nvidia.com/cuda/cublas/index.html#topic_8_2

Additionally I wrote tests for these function and a convenience decorator to define the wrappers only if the installed cuda version supports the corresponding library calls. The latter should save some typing. Due to time constraints, I only wrote wrappers for the float32 versions of the functions. 

Hope you'll integrate these changes in the main code-base.

Thanks,
Teodor Moldovan
