### PR TITLE
cublasCgemmBatched, cublasZgemmBatched wrappers

### DIFF
--- a/scikits/cuda/cublas.py
+++ b/scikits/cuda/cublas.py
@@ -5177,7 +5177,7 @@ if _cublas_version >= 5000:
 def cublasCgemmBatched(handle, transa, transb, m, n, k, 
                        alpha, A, lda, B, ldb, beta, C, ldc, batchCount):
     """
-    Matrix-matrix product for arrays of real general matrices.
+    Matrix-matrix product for arrays of complex general matrices.
 
     """
 
@@ -5212,7 +5212,7 @@ if _cublas_version >= 5000:
 def cublasZgemmBatched(handle, transa, transb, m, n, k, 
                        alpha, A, lda, B, ldb, beta, C, ldc, batchCount):
     """
-    Matrix-matrix product for arrays of real general matrices.
+    Matrix-matrix product for arrays of complex general matrices.
 
     """
 


### PR DESCRIPTION
I noticed that the wrappers for cublasCgemmBatched and cublasZgemmBatched were missing (the float and double versions are wrapped already). I need cublasCgemmBatched, so I added them.

I didn't write any tests for this since the modifications are pretty trivial (I just copied from cublasSgemmBatched and cublasCgemm), but I can have a go at writing one if it is necessary.

I am currently using scikits.cuda to build an FFT-based convolution operator for Theano. I need to do a batch of dot products in the Fourier domain to implement an input domain convolution, that's why I need cublasCgemmBatched. It's here, in case anyone is interested: https://github.com/benanne/theano_fftconv
