### PR TITLE
Find the version of cublas when it is only installed via LD_LIBRARY_PATH

### DIFF
--- a/scikits/cuda/cublas.py
+++ b/scikits/cuda/cublas.py
@@ -7,6 +7,7 @@ Note: this module does not explicitly depend on PyCUDA.
 """
 
 import re
+import os
 import sys
 import warnings
 import ctypes
@@ -225,8 +226,30 @@ def cublasGetVersion(handle):
 # We append zeros to match format of version returned by cublasGetVersion():
 # XXX This approach to obtaining the CUBLAS version number
 # may break Windows/MacOSX compatibility XXX
-_cublas_version = int(re.search('[\D\.]\.+(\d)',
-                                utils.get_soname(utils.find_lib_path('cublas'))).group(1) + '000')
+_cublas_path = utils.find_lib_path('cublas')
+if _cublas_path:
+    _cublas_version = int(re.search('[\D\.]\.+(\d)',
+                                utils.get_soname(_cublas_path)).group(1) + '000')
+else:
+    # If nvcc isn't installed system wide, the code above won't find it.
+    # Check the LD_LIBRARY_PATH env variable for nvcc
+    var = os.environ['LD_LIBRARY_PATH'].replace(":", " ")
+    if var:
+        f = os.popen('/sbin/ldconfig -vN %s 2>/dev/null' % var)
+        try:
+            data = f.read()
+        finally:
+            f.close()
+        expr = r'(\s+libcublas\.so.)([0123456789.]+)(.+)'
+        import pdb;pdb.set_trace()
+        res = re.search(expr, data)
+        if not res:
+            raise Exception("Unable to find cuda version")
+        _cublas_version = res.groups()[1].replace('.', '') + "00"
+    else:
+        raise Exception("Unable to find cuda version")
+
+    _cublas_version = "unknow"
 
 class _cublas_version_req(object):
     """


### PR DESCRIPTION
Without this, we can't use scikits.cuda when nvcc it is not installed system wide.
