### PR TITLE
make find_lib_path() work if LD_LIBARY_PATH is not set

### DIFF
--- a/scikits/cuda/utils.py
+++ b/scikits/cuda/utils.py
@@ -145,7 +145,8 @@ def find_lib_path(name):
 
     # First, check the directories in LD_LIBRARY_PATH:
     expr = r'\s+(lib%s\.[^\s]+)\s+\-\>' % re.escape(name)
-    for dir_path in os.environ['LD_LIBRARY_PATH'].split(':'):
+    for dir_path in filter(len,
+            os.environ.get('LD_LIBRARY_PATH', '').split(':')):
         f = os.popen('/sbin/ldconfig -Nnv %s 2>/dev/null' % dir_path)
         try:
             data = f.read()


### PR DESCRIPTION
If the `LD_LIBRARY_PATH` environment variable is not set, `utils.find_lib_path()` fails, so I cannot import `scikits.cuda.cublas`. Fixed with this pull request. (Bonus: Skips the empty string that occurs if you do `export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":/foo/bar:/some/more` with a previously empty `LD_LIBRARY_PATH`, which is probably a common pattern.)
