### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON = /usr/bin/python
-DESTDIR = /usr
+DESTDIR = /
 
 NAME = scikits.cuda
 VERSION = $(shell $(PYTHON) -c 'import setup; print setup.VERSION')


### PR DESCRIPTION
Doing `make install` caused scikits.cuda to be installed in  /usr/usr/local/python..... (mind the duplicate "/usr"), at least on Ubuntu 14.04. This PR fixes that.
