### PR TITLE
Fix bug in linalg.diag

### DIFF
--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -444,6 +444,12 @@ class test_linalg(TestCase):
         d_gpu = linalg.diag(v_gpu)
         assert np.all(np.diag(v) == d_gpu.get())
 
+    def test_diag_float32_large(self):
+        v = np.array(np.random.rand(64, 64), np.float32)
+        v_gpu = gpuarray.to_gpu(v)
+        d_gpu = linalg.diag(v_gpu)
+        assert np.all(np.diag(v) == d_gpu.get())
+
     def test_diag_float64(self):
         v = np.array([1, 2, 3, 4, 5, 6], np.float64)
         v_gpu = gpuarray.to_gpu(v)
@@ -680,6 +686,7 @@ def suite():
     s.addTest(test_linalg('test_hermitian_complex64'))
     s.addTest(test_linalg('test_conj_complex64'))
     s.addTest(test_linalg('test_diag_float32'))
+    s.addTest(test_linalg('test_diag_float32_large'))
     s.addTest(test_linalg('test_diag_complex64'))
     s.addTest(test_linalg('test_eye_float32'))
     s.addTest(test_linalg('test_eye_complex64'))


### PR DESCRIPTION
`linalg.diag` will corrupt memory (and cublas state) when extracting the diagonal of matrices that are larger than 32x32.  To see this, try:

```
    v = np.array(np.random.rand(64, 64), np.float32)
    v_gpu = gpuarray.to_gpu(v)
    d_gpu = linalg.diag(v_gpu)
    assert np.all(np.diag(v) == d_gpu.get())
```

The assert will fail, and all subsequent calls to PyCUDA stuff will also fail.  I'm not entirely sure why the original code worked, since -- at least to my understanding, the elementwise kernel used for the copy will start a thread for each element of the large matrix, and try to write an element in the diagonal. (So it has way to many writes that should fall out of bounds).

Anyhow, this PR should fix the bug. As additional benefit, it uses a cublas function so it doesn't need to go through a pycuda-compile cycle on its first call.
