### PR TITLE
Fix bug in linalg.eye.

### DIFF
--- a/scikits/cuda/linalg.py
+++ b/scikits/cuda/linalg.py
@@ -1235,8 +1235,8 @@ def eye(N, dtype=np.float32):
 
     e_gpu = misc.zeros((N, N), dtype)
     func = el.ElementwiseKernel("{ctype} *e".format(ctype=tools.dtype_to_ctype(dtype)),
-                                "e[i*%s] = 1" % (N+1))
-    func(e_gpu)
+                                "e[i] = 1")                            
+    func(e_gpu, slice=slice(0, N*N, N+1))
     return e_gpu
 
 def pinv(a_gpu, rcond=1e-15):

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -662,6 +662,11 @@ class test_linalg(TestCase):
 
     def test_add_diag_complex128(self):
         self.impl_test_add_diag(np.complex128)
+      
+    def test_eye_large_float32(self):
+        N = 128
+        e_gpu = linalg.eye(N, dtype=np.float32)
+        assert np.all(np.eye(N, dtype=np.float32) == e_gpu.get())		
 
 def suite():
     s = TestSuite()
@@ -703,6 +708,7 @@ def suite():
     s.addTest(test_linalg('test_add_diag_float32'))
     s.addTest(test_linalg('test_add_diag_complex64'))
     s.addTest(test_linalg('test_inv_exceptions'))
+    s.addTest(test_linalg('test_eye_large_float32'))
     if misc.get_compute_capability(pycuda.autoinit.device) >= 1.3:
         s.addTest(test_linalg('test_svd_ss_float64'))
         s.addTest(test_linalg('test_svd_ss_complex128'))


### PR DESCRIPTION
Commit 04646d78e8936f71dba709b5f821208fa77a8bef introduced a bug in  `linalg.eye`. It now fails for larger N. To see this, try:

```
import numpy as np
import pycuda.autoinit
from scikits.cuda import linalg
linalg.init()
print linalg.eye(128, dtype=np.float32)
```

This is because the ElementKernel tries to write outside the bounds of the array. This commit fixes that. Bonus: it also starts a lot less threads (N instead of the N*N that the original used).
