### PR TITLE
Fix add_diag testcases

### DIFF
--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -643,13 +643,14 @@ class test_linalg(TestCase):
         d = np.asarray(np.random.rand(1, 4), dtype).reshape(-1)
         x_gpu = gpuarray.to_gpu(x)
         d_gpu = gpuarray.to_gpu(d)
-        res_gpu = linalg.add_diag(d_gpu, x_gpu)
         res_cpu = x + np.diag(d)
-        assert np.allclose(res_cpu, res_gpu.get(), atol=1e-5)
-        assert res_gpu is x_gpu
         res_gpu = linalg.add_diag(d_gpu, x_gpu, overwrite=False)
         assert np.allclose(res_cpu, res_gpu.get(), atol=1e-5)
         assert res_gpu is not x_gpu
+        res_gpu = linalg.add_diag(d_gpu, x_gpu, overwrite=True)
+        assert np.allclose(res_cpu, res_gpu.get(), atol=1e-5)
+        assert res_gpu is x_gpu
+
 
     def test_add_diag_float32(self):
         self.impl_test_add_diag(np.float32)


### PR DESCRIPTION
Since the `overwrite` parameter to `linalg.add_diag` is now the inverse of what it was since the tests were originally written, they now fail:  The `overwrite=True` test was listed first and it overwrites the original input, making the consecutive test with `overwrite=False` fail because it works on a modified input array).
