### PR TITLE
ENH:  enable advanced data layout options in fft Plan class

### DIFF
--- a/scikits/cuda/fft.py
+++ b/scikits/cuda/fft.py
@@ -39,7 +39,22 @@ class Plan:
         the default stream is used.
     mode : int
         FFTW compatibility mode.
-
+    inembed : numpy.array with dtype=numpy.int32
+        number of elements in each dimension of the input array
+    istride : int
+        distance between two successive input elements in the least significant
+        (innermost) dimension
+    idist : int
+        distance between the first element of two consective batches in the
+        input data
+    onembed : numpy.array with dtype=numpy.int32
+        number of elements in each dimension of the output array
+    ostride : int
+        distance between two successive output elements in the least significant
+        (innermost) dimension
+    odist : int
+        distance between the first element of two consective batches in the
+        output data
     """
 
     def __init__(self, shape, in_dtype, out_dtype, batch=1, stream=None,


### PR DESCRIPTION
This pull request adds the remaining cufftPlanMany() arguments to the constructor of the Plan class defined in `scikits.cuda.fft.py`.  The new arguments define default values equal to the previously hard-coded values being passed to the function to maintain backwards compatiblity.

I recently needed access to the idist & odist arguments in order to perform a batch 3D C2C transform on 4D data that had been stored as a 2D gpuarray in fortran order with shape:  [ nx \* ny \* nz, nbatch].  The appropriate plan for this case turned out to be as follows:

```
N = np.asarray([nx, ny, nz])
Plan(N, np.complex64, np.complex64, idist=np.prod(N), odist=np.prod(N), batch=nbatch)
```

I did not need inembed/onembed or istride/ostride for my particular use case, but added them as well for completeness.
