### PR TITLE
FIX: Nest import to avoid unnecessary cublas import

### DIFF
--- a/scikits/cuda/misc.py
+++ b/scikits/cuda/misc.py
@@ -20,7 +20,6 @@ from pytools import memoize
 import numpy as np
 
 from . import cuda
-from . import cublas
 
 try:
     from . import cula
@@ -149,6 +148,7 @@ def init(allocator=drv.mem_alloc):
     # CUBLAS uses whatever device is being used by the host thread:
     global _global_cublas_handle, _global_cublas_allocator
     if not _global_cublas_handle:
+        from . import cublas  # nest to avoid requiring cublas e.g. for FFT
         _global_cublas_handle = cublas.cublasCreate()
 
     if _global_cublas_allocator is None:
@@ -174,6 +174,7 @@ def shutdown():
 
     global _global_cublas_handle
     if _global_cublas_handle:
+        from . import cublas  # nest to avoid requiring cublas e.g. for FFT
         cublas.cublasDestroy(_global_cublas_handle)
         _global_cublas_handle = None
 


### PR DESCRIPTION
So far in my code I only use `from scikits.cuda import fft`. On `master` this actually forces an import of `scikits.cuda.cublas` as well, because `.fft` looks for `.misc`, which in turn imports `.cublas`. This is a problem for me, because when importing `cublas` I get a warning about creating a context -- and it's also a bit inefficient in terms of importing to have to go through these steps to get FFT use.

This fixes the issue by nesting the import of `.cublas` to the two places it's used. A more comprehensive solution might involve refactoring the code to make these bits of code (cublas, fft, and misc) more orthogonal if possible, but the current solution has the advantage of being very simple as only a +2/-1 change :)
