### PR TITLE
sys.platform == 'win32':

### DIFF
--- a/skcuda/cusolver.py
+++ b/skcuda/cusolver.py
@@ -26,7 +26,7 @@ if 'linux' in sys.platform:
 elif sys.platform == 'darwin':
     _libcusolver_libname_list = ['libcusolver.dylib']
 elif sys.platform == 'win32':
-    if platform.machine().endswith('64'):
+    if sys.maxsize > 2**32:
         _libcusolver_libname_list = ['cusolver.dll'] + \
                                     ['cusolver64_%s.dll' % int(10*v) for v in _version_list]
     else:


### PR DESCRIPTION
> platform.machine().endswith('64')

or 

> sys.platform.machine().endswith('64')

Does not work with Windows 10. Better is

> sys.maxsize > 2**32

See https://docs.python.org/2/library/platform.html
