### PR TITLE
Changed int32_t to int for better Windows compatibility.

### DIFF
--- a/skcuda/misc.py
+++ b/skcuda/misc.py
@@ -820,7 +820,7 @@ def _get_binaryop_vecmat_kernel(dtype, binary_op):
     #include <pycuda-complex.hpp>
 
     __global__ void opColVecToMat(const ${type} *mat, const ${type} *vec, ${type} *out,
-                                   const int32_t n, const int32_t m){
+                                   const int n, const int m){
         const int tx = threadIdx.x;
         const int ty = threadIdx.y;
         const int tidx = blockIdx.x * blockDim.x + threadIdx.x;


### PR DESCRIPTION
In the misc module,  opColVecToMat, I changed int32_t to int. int_32t was not defined in my CUDA-C environment and this is apparently common with Windows systems. As a result, any kernel calls originating from opColVecToMat would result in compilation errors. 