### PR TITLE
Support and use cufft extensible plan API

### DIFF
--- a/skcuda/cufft.py
+++ b/skcuda/cufft.py
@@ -572,3 +572,133 @@ def cufftGetSize(plan):
     status = _libcufft.cufftGetSize(plan, ctypes.byref(worksize))
     cufftCheckStatus(status)
     return worksize.value
+
+_libcufft.cufftCreate.restype = int
+_libcufft.cufftCreate.argtypes = [ctypes.c_void_p]
+def cufftCreate():
+    """
+    Creates only an opaque handle.
+
+    References
+    ----------
+    `cufftCreate <http://docs.nvidia.com/cuda/cufft/#function-cufftcreate>`_
+    """
+    plan = _types.plan()
+    status = _libcufft.cufftCreate(ctypes.byref(plan))
+    cufftCheckStatus(status)
+    return plan
+
+_libcufft.cufftMakePlan1d.restype = int
+_libcufft.cufftMakePlan1d.argtypes = [_types.plan,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p]
+def cufftMakePlan1d(plan, nx, fft_type, batch):
+    """
+    Create 1D FFT plan configuration.
+
+    References
+    ----------
+    `cufftMakePlan1d <http://docs.nvidia.com/cuda/cufft/#function-cufftmakeplan1d>`_
+    """
+    worksize = _types.worksize()
+    status = _libcufft.cufftMakePlan1d(plan, nx, fft_type, batch,
+                                       ctypes.byref(worksize))
+    cufftCheckStatus(status)
+    return worksize.value
+
+_libcufft.cufftMakePlan2d.restype = int
+_libcufft.cufftMakePlan2d.argtypes = [_types.plan,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p]
+def cufftMakePlan2d(plan, nx, ny, fft_type):
+    """
+    Create 2D FFT plan configuration.
+
+    References
+    ----------
+    `cufftMakePlan2d <http://docs.nvidia.com/cuda/cufft/#function-cufftmakeplan2d>`_
+    """
+    worksize = _types.worksize()
+    status = _libcufft.cufftMakePlan2d(plan, nx, ny, fft_type,
+                                       ctypes.byref(worksize))
+    cufftCheckStatus(status)
+    return worksize.value
+
+_libcufft.cufftMakePlan3d.restype = int
+_libcufft.cufftMakePlan3d.argtypes = [_types.plan,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p]
+def cufftMakePlan3d(plan, nx, ny, nz, fft_type):
+    """
+    Create 3D FFT plan configuration.
+
+    References
+    ----------
+    `cufftMakePlan3d <http://docs.nvidia.com/cuda/cufft/#function-cufftmakeplan3d>`_
+    """
+    worksize = _types.worksize()
+    status = _libcufft.cufftMakePlan3d(plan, nx, ny, nz, fft_type,
+                                       ctypes.byref(worksize))
+    cufftCheckStatus(status)
+    return worksize.value
+
+_libcufft.cufftMakePlanMany.restype = int
+_libcufft.cufftMakePlanMany.argtypes = [_types.plan,
+                                        ctypes.c_int,
+                                        ctypes.c_void_p,
+                                        ctypes.c_void_p,
+                                        ctypes.c_int,
+                                        ctypes.c_int,
+                                        ctypes.c_void_p,
+                                        ctypes.c_int,
+                                        ctypes.c_int,
+                                        ctypes.c_int,
+                                        ctypes.c_int,
+                                        ctypes.c_void_p]
+def cufftMakePlanMany(plan, rank, n,
+                      inembed, istride, idist,
+                      onembed, ostride, odist, fft_type, batch):
+    worksize = _types.worksize()
+    status = _libcufft.cufftMakePlanMany(plan, rank, n,
+                                         inembed, istride, idist,
+                                         onembed, ostride, odist,
+                                         fft_type, batch,
+                                         ctypes.byref(worksize))
+    cufftCheckStatus(status)
+    return worksize.value
+
+_libcufft.cufftSetAutoAllocation.restype = int
+_libcufft.cufftSetAutoAllocation.argtypes = [_types.plan,
+                                             ctypes.c_int]
+def cufftSetAutoAllocation(plan, auto_allocate):
+    """
+    Indicate whether the caller intends to allocate and manage work areas for
+    plans that have been generated.
+
+    References
+    ----------
+    `cufftSetAutoAllocation <http://docs.nvidia.com/cuda/cufft/#function-cufftsetautoallocation>`_
+    """
+    status = _libcufft.cufftSetAutoAllocation(plan, auto_allocate)
+    cufftCheckStatus(status)
+
+_libcufft.cufftSetWorkArea.restype = int
+_libcufft.cufftSetWorkArea.argtypes = [_types.plan,
+                                       ctypes.c_void_p]
+def cufftSetWorkArea(plan, work_area):
+    """
+    Override the work area pointer associated with a plan.
+
+    References
+    ----------
+    `cufftSetworkArea <http://docs.nvidia.com/cuda/cufft/#function-cufftsetworkarea>`_
+    """
+    status = _libcufft.cufftSetWorkArea(plan, work_area)
+    cufftCheckStatus(status)

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -212,6 +212,17 @@ class test_fft(TestCase):
         assert np.allclose(xf, xf_gpu.get(), atol=atol_float32)
         assert np.allclose(yf, yf_gpu.get(), atol=atol_float32)
 
+    def test_work_area(self):
+        x = np.asarray(np.random.rand(self.N), np.float32)
+        xf = np.fft.rfftn(x)
+        x_gpu = gpuarray.to_gpu(x)
+        xf_gpu = gpuarray.empty(self.N//2+1, np.complex64)
+        plan = fft.Plan(x.shape, np.float32, np.complex64, auto_allocate=False)
+        work_area = gpuarray.empty((plan.worksize,), np.uint8)
+        plan.set_work_area(work_area)
+        fft.fft(x_gpu, xf_gpu, plan)
+        assert np.allclose(xf, xf_gpu.get(), atol=atol_float32)
+
 def suite():
     s = TestSuite()
     s.addTest(test_fft('test_fft_float32_to_complex64_1d'))


### PR DESCRIPTION
This change adds support for CUFFT's "extensible plan" API, in which
a handle is first created with cufftCreate and the actual plan made
later by cufftMakePlan*. This API is also used in the high-level Plan
object, since it allows parameters like compatibility mode to be set
before creating the plan (recommended by cufft docs).

Finally, support is added for caller-managed work area allocation. At
the low level, cufftSetAutoAllocation and cufftSetWorkArea are added. At
the high level, Plan() takes an auto_allocate argument, and adds a
Plan.set_work_area method.

This does not support the multi-GPU API, but it will be easier to add in
future because it is built on the extensible API. There are fundamental
issues with adding support, because for some pointer arguments there is
no way to know how many elements are being pointed to.