### PR TITLE
Removing trans.encode since cusolver expects an int

### DIFF
--- a/skcuda/cusolver.py
+++ b/skcuda/cusolver.py
@@ -634,7 +634,7 @@ def cusolverDnSgetrs(handle, trans, n, nrhs, A, lda,
     `cusolverDn<t>getrs <http://docs.nvidia.com/cuda/cusolver/index.html#cuds-lt-t-gt-getrs>`_
     """
 
-    trans = trans.encode('ascii')
+    # trans = trans.encode('ascii')
     status = _libcusolver.cusolverDnSgetrs(handle, trans, n, nrhs,
                                            int(A), lda,
                                            int(devIpiv), int(B),


### PR DESCRIPTION
Related to #191, Theano/Theano#5844, and the [helpful reply from notoraptor](https://groups.google.com/forum/#!topic/theano-users/UUzyiEwZSJk) on the theano-users group, it seems that cusolver [expects an int in the trans parameter](http://docs.nvidia.com/cuda/cusolver/index.html#cuds-lt-t-gt-getrs), causing theano's `gpu_solve` to fail with the most recent versions of scikit-cuda.
