### PR TITLE
Set LANG to en when doing a callout.

### DIFF
--- a/skcuda/utils.py
+++ b/skcuda/utils.py
@@ -48,7 +48,8 @@ except ImportError:
             cmds = ['objdump', '-p', filename]
 
         try:
-            p = subprocess.Popen(cmds, stdout=subprocess.PIPE)
+            p = subprocess.Popen(cmds, stdout=subprocess.PIPE,
+                                 env=dict(os.environ, LANG="en"))
             out = p.communicate()[0].decode()
         except:
             raise RuntimeError('error executing {0}'.format(cmds))


### PR DESCRIPTION
This fixes a problem on linux distros where objdump changes its output according to the locale (looking at you Debian).  This may lead to non-ascii characters in the output which then make the decode() fail.
