### PR TITLE
Adding a few more wrappers for symmetric matrix eigen decomposition routines

### DIFF
--- a/demos/cusolver_demo_DnCheevjBatched.py
+++ b/demos/cusolver_demo_DnCheevjBatched.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+Demo of how to call low-level CUSOLVER wrappers to perform eigen decomposition
+for a batch of small Hermitian matrices.
 """
 
 import numpy as np
@@ -21,48 +22,49 @@ for i in range(batchSize):
     x = x+x.conj().T
     x = x.astype(np.complex64)
     A[i*n:(i+1)*n, :] = x
+    # Need to reverse dimensions because CUSOLVER expects column-major matrices:
     B[i*n:(i+1)*n, :] = x.T.copy()
 
-# Need to reverse dimensions because CUSOLVER expects column-major matrices:
 x_gpu = gpuarray.to_gpu(B)
 
 # Set up output buffers:
 w_gpu = gpuarray.empty((batchSize, n), dtype = np.float32)
 
-# Set up work buffers:
+# Set up parameters
 params = solver.cusolverDnCreateSyevjInfo()
 solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
 solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
 
-
+# Set up work buffers:
 lwork = solver.cusolverDnCheevjBatched_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                                     'u', n, x_gpu.gpudata, n,
                                     w_gpu.gpudata, params, batchSize)
-print lwork
+
 workspace_gpu = gpuarray.zeros(lwork, dtype = A.dtype)
 info = gpuarray.zeros(batchSize, dtype = np.int32)
+
 # Compute:
 solver.cusolverDnCheevjBatched(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                        'u', n, x_gpu.gpudata, n,
                         w_gpu.gpudata, workspace_gpu.gpudata,
                         lwork, info.gpudata, params, batchSize)
 
-# print solver.cusolverDnXsyevjGetSweeps(handle, params)
-# print solver.cusolverDnXsyevjGetResidual(handle, params)
-
+# Print info
 tmp = info.get()
 if any(tmp):
     print "the following job did not converge:", np.nonzero(tmp)[0]
 else:
     print "all jobs converged"
-# print info
+
+# Destroy handle
 solver.cusolverDnDestroySyevjInfo(params)
 solver.cusolverDnDestroy(handle)
 
 Q = x_gpu.get()
 W = w_gpu.get()
+print 'maximum error in A * Q - Q * Lambda is:'
 for i in range(batchSize):
     q = Q[i*n:(i+1)*n,:].T.copy()
     x = A[i*n:(i+1)*n,:].copy()
     w = W[i, :].copy()
-    print i, np.abs(np.dot(x, q) - np.dot(q, np.diag(w))).max()
+    print '{}th matrix'.format(i), np.abs(np.dot(x, q) - np.dot(q, np.diag(w))).max()

--- a/demos/cusolver_demo_DnCheevjBatched.py
+++ b/demos/cusolver_demo_DnCheevjBatched.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+"""
+Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+"""
+
+import numpy as np
+import pycuda.autoinit
+import pycuda.gpuarray as gpuarray
+import skcuda.cusolver as solver
+
+handle = solver.cusolverDnCreate()
+batchSize = 100
+n = 9
+
+A = np.empty((n*batchSize, n), dtype = np.complex64)
+B = np.empty((n*batchSize, n), dtype = A.dtype)
+
+for i in range(batchSize):
+    x = np.random.randn(n, n)+1j*np.random.randn(n,n)
+    x = x+x.conj().T
+    x = x.astype(np.complex64)
+    A[i*n:(i+1)*n, :] = x
+    B[i*n:(i+1)*n, :] = x.T.copy()
+
+# Need to reverse dimensions because CUSOLVER expects column-major matrices:
+x_gpu = gpuarray.to_gpu(B)
+
+# Set up output buffers:
+w_gpu = gpuarray.empty((batchSize, n), dtype = np.float32)
+
+# Set up work buffers:
+params = solver.cusolverDnCreateSyevjInfo()
+solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
+solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
+
+
+lwork = solver.cusolverDnCheevjBatched_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                                    'u', n, x_gpu.gpudata, n,
+                                    w_gpu.gpudata, params, batchSize)
+print lwork
+workspace_gpu = gpuarray.zeros(lwork, dtype = A.dtype)
+info = gpuarray.zeros(batchSize, dtype = np.int32)
+# Compute:
+solver.cusolverDnCheevjBatched(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                       'u', n, x_gpu.gpudata, n,
+                        w_gpu.gpudata, workspace_gpu.gpudata,
+                        lwork, info.gpudata, params, batchSize)
+
+# print solver.cusolverDnXsyevjGetSweeps(handle, params)
+# print solver.cusolverDnXsyevjGetResidual(handle, params)
+
+tmp = info.get()
+if any(tmp):
+    print "the following job did not converge:", np.nonzero(tmp)[0]
+else:
+    print "all jobs converged"
+# print info
+solver.cusolverDnDestroySyevjInfo(params)
+solver.cusolverDnDestroy(handle)
+
+Q = x_gpu.get()
+W = w_gpu.get()
+for i in range(batchSize):
+    q = Q[i*n:(i+1)*n,:].T.copy()
+    x = A[i*n:(i+1)*n,:].copy()
+    w = W[i, :].copy()
+    print i, np.abs(np.dot(x, q) - np.dot(q, np.diag(w))).max()

--- a/demos/cusolver_demo_DnDsyevj.py
+++ b/demos/cusolver_demo_DnDsyevj.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""
+Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+"""
+
+import numpy as np
+import pycuda.autoinit
+import pycuda.gpuarray as gpuarray
+import skcuda.cusolver as solver
+
+handle = solver.cusolverDnCreate()
+x = np.random.randn(1024,1024).astype(np.double)
+x = x+x.T
+
+# Need to reverse dimensions because CUSOLVER expects column-major matrices:
+n, m = x.shape
+x_gpu = gpuarray.to_gpu(x)
+
+# Set up output buffers:
+w = gpuarray.empty(n, dtype = x.dtype)
+
+# Set up work buffers:
+params = solver.cusolverDnCreateSyevjInfo()
+solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
+solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
+
+lwork = solver.cusolverDnDsyevj_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                                    'u', n, x_gpu.gpudata, m,
+                                    w.gpudata, params)
+print lwork
+workspace_gpu = gpuarray.zeros(lwork, dtype = x.dtype)
+info = gpuarray.zeros(1, dtype = np.int32)
+# Compute:
+solver.cusolverDnDsyevj(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                       'u', n, x_gpu.gpudata, m,
+                        w.gpudata, workspace_gpu.gpudata,
+                        lwork, info.gpudata, params)
+
+print solver.cusolverDnXsyevjGetSweeps(handle, params)
+print solver.cusolverDnXsyevjGetResidual(handle, params)
+
+# print info
+solver.cusolverDnDestroySyevjInfo(params)
+solver.cusolverDnDestroy(handle)
+
+Q = x_gpu.get().T
+print np.abs(np.dot(x, Q) - np.dot(Q, np.diag(w.get()))).max()

--- a/demos/cusolver_demo_DnDsyevj.py
+++ b/demos/cusolver_demo_DnDsyevj.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+Demo of how to call low-level CUSOLVER wrappers to perform eigen decomposition
+for symmetric matrices.
 """
 
 import numpy as np
@@ -20,29 +21,32 @@ x_gpu = gpuarray.to_gpu(x)
 # Set up output buffers:
 w = gpuarray.empty(n, dtype = x.dtype)
 
-# Set up work buffers:
+# Set up parameters
 params = solver.cusolverDnCreateSyevjInfo()
 solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
 solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
 
+# Set up work buffers:
 lwork = solver.cusolverDnDsyevj_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                                     'u', n, x_gpu.gpudata, m,
                                     w.gpudata, params)
-print lwork
 workspace_gpu = gpuarray.zeros(lwork, dtype = x.dtype)
 info = gpuarray.zeros(1, dtype = np.int32)
+
 # Compute:
 solver.cusolverDnDsyevj(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                        'u', n, x_gpu.gpudata, m,
                         w.gpudata, workspace_gpu.gpudata,
                         lwork, info.gpudata, params)
 
+# Print info
 print solver.cusolverDnXsyevjGetSweeps(handle, params)
 print solver.cusolverDnXsyevjGetResidual(handle, params)
 
-# print info
+# Destroy handle
 solver.cusolverDnDestroySyevjInfo(params)
 solver.cusolverDnDestroy(handle)
 
+# Check error
 Q = x_gpu.get().T
-print np.abs(np.dot(x, Q) - np.dot(Q, np.diag(w.get()))).max()
+print 'maximum error in A * Q - Q * Lambda is:', np.abs(np.dot(x, Q) - np.dot(Q, np.diag(w.get()))).max()

--- a/demos/cusolver_demo_DnDsyevjBatched.py
+++ b/demos/cusolver_demo_DnDsyevjBatched.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+Demo of how to call low-level CUSOLVER wrappers to perform eigen decomposition
+for a batch of small symmetric matrices.
 """
 
 import numpy as np
@@ -20,44 +21,44 @@ for i in range(batchSize):
     x = x+x.T
     A[i*n:(i+1)*n, :] = x
 
-# Need to reverse dimensions because CUSOLVER expects column-major matrices:
 x_gpu = gpuarray.to_gpu(A)
 
 # Set up output buffers:
 w_gpu = gpuarray.empty((batchSize, n), dtype = A.dtype)
 
-# Set up work buffers:
+# Set up parameters
 params = solver.cusolverDnCreateSyevjInfo()
 solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
 solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
 
-
+# Set up work buffers:
 lwork = solver.cusolverDnDsyevjBatched_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                                     'u', n, x_gpu.gpudata, n,
                                     w_gpu.gpudata, params, batchSize)
-print lwork
+
 workspace_gpu = gpuarray.zeros(lwork, dtype = A.dtype)
 info = gpuarray.zeros(batchSize, dtype = np.int32)
+
 # Compute:
 solver.cusolverDnDsyevjBatched(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                        'u', n, x_gpu.gpudata, n,
                         w_gpu.gpudata, workspace_gpu.gpudata,
                         lwork, info.gpudata, params, batchSize)
 
-# print solver.cusolverDnXsyevjGetSweeps(handle, params)
-# print solver.cusolverDnXsyevjGetResidual(handle, params)
-
+# print info
 tmp = info.get()
 if any(tmp):
     print "the following job did not converge:", np.nonzero(tmp)[0]
-# print info
+
+# Destroy handle
 solver.cusolverDnDestroySyevjInfo(params)
 solver.cusolverDnDestroy(handle)
 
 Q = x_gpu.get()
 W = w_gpu.get()
+print 'maximum error in A * Q - Q * Lambda is:'
 for i in range(batchSize):
     q = Q[i*n:(i+1)*n,:].T.copy()
     x = A[i*n:(i+1)*n,:].copy()
     w = W[i, :].copy()
-    print i, np.abs(np.dot(x, q) - np.dot(q, np.diag(w))).max()
+    print '{}th matrix'.format(i), np.abs(np.dot(x, q) - np.dot(q, np.diag(w))).max()

--- a/demos/cusolver_demo_DnDsyevjBatched.py
+++ b/demos/cusolver_demo_DnDsyevjBatched.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+"""
+Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+"""
+
+import numpy as np
+import pycuda.autoinit
+import pycuda.gpuarray as gpuarray
+import skcuda.cusolver as solver
+
+handle = solver.cusolverDnCreate()
+batchSize = 100
+n = 9
+
+A = np.empty((n*batchSize, n), dtype = np.double)
+
+for i in range(batchSize):
+    x = np.random.randn(n, n)
+    x = x+x.T
+    A[i*n:(i+1)*n, :] = x
+
+# Need to reverse dimensions because CUSOLVER expects column-major matrices:
+x_gpu = gpuarray.to_gpu(A)
+
+# Set up output buffers:
+w_gpu = gpuarray.empty((batchSize, n), dtype = A.dtype)
+
+# Set up work buffers:
+params = solver.cusolverDnCreateSyevjInfo()
+solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
+solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
+
+
+lwork = solver.cusolverDnDsyevjBatched_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                                    'u', n, x_gpu.gpudata, n,
+                                    w_gpu.gpudata, params, batchSize)
+print lwork
+workspace_gpu = gpuarray.zeros(lwork, dtype = A.dtype)
+info = gpuarray.zeros(batchSize, dtype = np.int32)
+# Compute:
+solver.cusolverDnDsyevjBatched(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                       'u', n, x_gpu.gpudata, n,
+                        w_gpu.gpudata, workspace_gpu.gpudata,
+                        lwork, info.gpudata, params, batchSize)
+
+# print solver.cusolverDnXsyevjGetSweeps(handle, params)
+# print solver.cusolverDnXsyevjGetResidual(handle, params)
+
+tmp = info.get()
+if any(tmp):
+    print "the following job did not converge:", np.nonzero(tmp)[0]
+# print info
+solver.cusolverDnDestroySyevjInfo(params)
+solver.cusolverDnDestroy(handle)
+
+Q = x_gpu.get()
+W = w_gpu.get()
+for i in range(batchSize):
+    q = Q[i*n:(i+1)*n,:].T.copy()
+    x = A[i*n:(i+1)*n,:].copy()
+    w = W[i, :].copy()
+    print i, np.abs(np.dot(x, q) - np.dot(q, np.diag(w))).max()

--- a/demos/cusolver_demo_DnZheevj.py
+++ b/demos/cusolver_demo_DnZheevj.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+"""
+Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+"""
+
+import numpy as np
+import pycuda.autoinit
+import pycuda.gpuarray as gpuarray
+import skcuda.cusolver as solver
+
+handle = solver.cusolverDnCreate()
+x = np.random.randn(1024,1024)+1j*np.random.rand(1024,1024)
+x = x+x.conj().T
+
+# Need to reverse dimensions because CUSOLVER expects column-major matrices:
+n, m = x.shape
+x_gpu = gpuarray.to_gpu(x.T.copy())
+
+# Set up output buffers:
+w = gpuarray.empty(n, dtype = np.double)
+
+# Set up work buffers:
+params = solver.cusolverDnCreateSyevjInfo()
+solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
+solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
+
+
+lwork = solver.cusolverDnZheevj_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                                    'u', n, x_gpu.gpudata, m,
+                                    w.gpudata, params)
+print lwork
+workspace_gpu = gpuarray.zeros(lwork, dtype = x.dtype)
+info = gpuarray.zeros(1, dtype = np.int32)
+# Compute:
+solver.cusolverDnZheevj(handle, 'CUSOLVER_EIG_MODE_VECTOR',
+                       'u', n, x_gpu.gpudata, m,
+                        w.gpudata, workspace_gpu.gpudata,
+                        lwork, info.gpudata, params)
+
+print solver.cusolverDnXsyevjGetSweeps(handle, params)
+print solver.cusolverDnXsyevjGetResidual(handle, params)
+
+# print info
+solver.cusolverDnDestroySyevjInfo(params)
+solver.cusolverDnDestroy(handle)
+
+Q = x_gpu.get().T
+print np.abs(np.dot(x, Q) - np.dot(Q, np.diag(w.get()))).max()

--- a/demos/cusolver_demo_DnZheevj.py
+++ b/demos/cusolver_demo_DnZheevj.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-Demo of how to call low-level CUSOLVER wrappers to perform SVD decomposition.
+Demo of how to call low-level CUSOLVER wrappers to perform eigen decomposition
+for Hermitian matrices.
 """
 
 import numpy as np
@@ -20,30 +21,33 @@ x_gpu = gpuarray.to_gpu(x.T.copy())
 # Set up output buffers:
 w = gpuarray.empty(n, dtype = np.double)
 
-# Set up work buffers:
+# Set up parameters
 params = solver.cusolverDnCreateSyevjInfo()
 solver.cusolverDnXsyevjSetTolerance(params, 1e-7)
 solver.cusolverDnXsyevjSetMaxSweeps(params, 15)
 
-
+# Set up work buffers:
 lwork = solver.cusolverDnZheevj_bufferSize(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                                     'u', n, x_gpu.gpudata, m,
                                     w.gpudata, params)
-print lwork
+
 workspace_gpu = gpuarray.zeros(lwork, dtype = x.dtype)
 info = gpuarray.zeros(1, dtype = np.int32)
+
 # Compute:
 solver.cusolverDnZheevj(handle, 'CUSOLVER_EIG_MODE_VECTOR',
                        'u', n, x_gpu.gpudata, m,
                         w.gpudata, workspace_gpu.gpudata,
                         lwork, info.gpudata, params)
 
+# Print info
 print solver.cusolverDnXsyevjGetSweeps(handle, params)
 print solver.cusolverDnXsyevjGetResidual(handle, params)
 
-# print info
+# Destroy handle
 solver.cusolverDnDestroySyevjInfo(params)
 solver.cusolverDnDestroy(handle)
 
+# Check error
 Q = x_gpu.get().T
-print np.abs(np.dot(x, Q) - np.dot(Q, np.diag(w.get()))).max()
+print 'maximum error in A * Q - Q * Lambda is:', np.abs(np.dot(x, Q) - np.dot(Q, np.diag(w.get()))).max()

--- a/skcuda/cudart.py
+++ b/skcuda/cudart.py
@@ -8,7 +8,7 @@ import atexit, ctypes, platform, re, sys, warnings
 import numpy as np
 
 # Load library:
-_version_list = [8.0, 7.5, 7.0, 6.5, 6.0, 5.5, 5.0, 4.0]
+_version_list = [9.0, 8.0, 7.5, 7.0, 6.5, 6.0, 5.5, 5.0, 4.0]
 if 'linux' in sys.platform:
     _libcudart_libname_list = ['libcudart.so'] + \
                               ['libcudart.so.%s' % v for v in _version_list]
@@ -785,8 +785,33 @@ def cudaDriverGetVersion():
     cudaCheckStatus(status)
     return version.value
 
+# try:
+#     _cudart_version = cudaDriverGetVersion()
+# except:
+#     _cudart_version = 9999
+
+_libcudart.cudaRuntimeGetVersion.restype = int
+_libcudart.cudaRuntimeGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
+def cudaRuntimeGetVersion():
+    """
+    Get installed CUDA driver version.
+
+    Return the version of the installed CUDA driver as an integer. If
+    no driver is detected, 0 is returned.
+
+    Returns
+    -------
+    version : int
+        Driver version.
+    """
+
+    version = ctypes.c_int()
+    status = _libcudart.cudaRuntimeGetVersion(ctypes.byref(version))
+    cudaCheckStatus(status)
+    return version.value
+
 try:
-    _cudart_version = cudaDriverGetVersion()
+    _cudart_version = cudaRuntimeGetVersion()
 except:
     _cudart_version = 9999
 

--- a/skcuda/cudart.py
+++ b/skcuda/cudart.py
@@ -785,11 +785,6 @@ def cudaDriverGetVersion():
     cudaCheckStatus(status)
     return version.value
 
-# try:
-#     _cudart_version = cudaDriverGetVersion()
-# except:
-#     _cudart_version = 9999
-
 _libcudart.cudaRuntimeGetVersion.restype = int
 _libcudart.cudaRuntimeGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
 def cudaRuntimeGetVersion():

--- a/skcuda/cusolver.py
+++ b/skcuda/cusolver.py
@@ -1818,7 +1818,7 @@ def cusolverDnSsyevj_bufferSize(handle, jobz, uplo,
     lwork = ctypes.c_int()
     status = _libcusolver.cusolverDnSsyevj_bufferSize(
         handle,
-        _CUSOLVER_EIG_TYPE[jobz],
+        _CUSOLVER_EIG_MODE[jobz],
         cublas._CUBLAS_FILL_MODE[uplo],
         n,
         int(a),
@@ -1847,11 +1847,10 @@ if cudart._cudart_version >= 9000:
 @_cusolver_version_req(9.0)
 def cusolverDnSsyevj(handle, jobz, uplo,
                      n, a, lda, w, work,
-                     lwork, params):
-    info = ctypes.c_int()
+                     lwork, info, params):
     status = _libcusolver.cusolverDnSsyevj(
         handle,
-        _CUSOLVER_EIG_TYPE[jobz],
+        _CUSOLVER_EIG_MODE[jobz],
         cublas._CUBLAS_FILL_MODE[uplo],
         n,
         int(a),
@@ -1859,11 +1858,10 @@ def cusolverDnSsyevj(handle, jobz, uplo,
         int(w),
         int(work),
         lwork,
-        ctypes.byref(info),
+        int(info),
         params
     )
     cusolverCheckStatus(status)
-    return info
 
 if cudart._cudart_version >= 9000:
     _libcusolver.cusolverDnDsyevj_bufferSize.restype = int


### PR DESCRIPTION
In addition to the wrappers, I changed cudart._cudart_version to use cudaRuntimeVersion instead of cudaDriverVersion. Here is an example that cusolver cannot be loaded correctly when using driver version:
I have latest CUDA driver that correspond to driver version 9.0, but using cuda toolkit 8.0. Using driver version as _cudart_version, cusolver.py cannot find functions that require 9.0, since it's loading 8.0 libraries.