### PR TITLE
switch to absolute import path

### DIFF
--- a/skcuda/__init__.py
+++ b/skcuda/__init__.py
@@ -11,5 +11,4 @@ from .version import __version__
 
 # Location of headers:
 import os
-install_headers = \
-    __file__.replace(os.path.basename(__file__), '') + 'include'
+install_headers = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'include')


### PR DESCRIPTION
I've seen failures like
```
CompileError: nvcc compilation of /tmp/tmplopoyu/kernel.cu failed
[command: nvcc --cubin -I skcuda/include -arch sm_61 -I/usr/lib/python2.7/dist-packages/pycuda/cuda kernel.cu]
[stderr:
kernel.cu:5:36: fatal error: cuSpecialFuncs.h: No such file or directory
compilation terminated.
]
```

Using an absolute import seems more robust.