### PR TITLE
Fix QR tests on python 3 (revert #131 workaround)

### DIFF
--- a/skcuda/cublasxt.py
+++ b/skcuda/cublasxt.py
@@ -8,7 +8,7 @@ Note: this module does not explicitly depend on PyCUDA.
 
 import ctypes
 
-from cublas import cublasCheckStatus, _libcublas, _CUBLAS_OP
+from .cublas import cublasCheckStatus, _libcublas, _CUBLAS_OP
 from . import cuda
 
 CUBLASXT_FLOAT = 0

--- a/skcuda/pcula.py
+++ b/skcuda/pcula.py
@@ -7,8 +7,8 @@ Python interface to multi-GPU CULA toolkit functions.
 import ctypes
 import sys
 
-import cuda
-from cula import culaCheckStatus
+from . import cuda
+from .cula import culaCheckStatus
 
 if 'linux' in sys.platform:
     _libpcula_libname_list = ['libcula_scalapack.so']


### PR DESCRIPTION
```
======================================================================
ERROR: test_qr_reduced_cusolver_complex128 (test_linalg.test_linalg)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sclarkson/scikit-cuda/tests/test_linalg.py", line 1479, in test_qr_reduced_cusolver_complex128
    self._impl_test_qr_reduced(np.complex128, 'cusolver')
  File "/home/sclarkson/scikit-cuda/tests/test_linalg.py", line 1451, in _impl_test_qr_reduced
    assert_allclose(a, np.dot(q_gpu.get(), r_gpu.get()), atol=1e-4)
  File "/usr/lib/python3/dist-packages/pycuda/gpuarray.py", line 271, in get
    _memcpy_discontig(ary, self, async=async, stream=stream)
  File "/usr/lib/python3/dist-packages/pycuda/gpuarray.py", line 1265, in _memcpy_discontig
    copy.set_src_device(src.gpudata)
Boost.Python.ArgumentError: Python argument types in
    Memcpy2D.set_src_device(Memcpy2D, numpy.int64)
did not match C++ signature:
    set_src_device(pycuda::memcpy_2d {lvalue}, unsigned long long)
```

The reason only the QR tests were failing is that R is a slice of a computed array.

https://github.com/lebedov/scikit-cuda/blob/ff1884e8a745cf544b21586dc07541494e7304f2/skcuda/linalg.py#L2645-L2646

The changes from #131  are to blame. Try this sample
```
import pycuda.autoinit
import skcuda.autoinit
from pycuda import gpuarray
import numpy as np
a = gpuarray.empty((1,2), np.float32)
print(a)
print(a[:,:1])
b = gpuarray.empty(np.array((1,2), int), np.float32)
print(b)
print(b[:,:1])
```

Python 2 output:
```
[[ 0.  0.]]
[[ 0.]]
[[ 0.  0.]]
[[ 0.]]
```

Python 3 output:
```
[[ 0.  0.]]
[[ 0.]]
[[ 0.  0.]]
Traceback (most recent call last):
  File "test.py", line 10, in <module>
    print(b[:,:1])
  File "/usr/lib/python3/dist-packages/pycuda/gpuarray.py", line 283, in __str__
    return str(self.get())
  File "/usr/lib/python3/dist-packages/pycuda/gpuarray.py", line 271, in get
    _memcpy_discontig(ary, self, async=async, stream=stream)
  File "/usr/lib/python3/dist-packages/pycuda/gpuarray.py", line 1248, in _memcpy_discontig
    drv.memcpy_dtoh(dst, src.gpudata)
Boost.Python.ArgumentError: Python argument types in
    pycuda._driver.memcpy_dtoh(numpy.ndarray, numpy.int64)
did not match C++ signature:
    memcpy_dtoh(boost::python::api::object dest, unsigned long long src)
```


After these commits, my python 3 tests pass with the exceptions of cublasXt*gemm (#181), and some reproducible tolerance failures. I have not tested with CULA, only with cusolver. Edit: I see now you have already adjusted the tolerances.

The fix in PyCUDA https://github.com/inducer/pycuda/commit/743d66450ba2f106bb2c157b8ba108c400461499 looks like it was first tagged at 2016.1. The minimum version should possibly be updated to this.