### PR TITLE
Ran sphinx-lint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,8 @@ Development
 The latest source code can be obtained from
 `<https://github.com/lebedov/scikit-cuda>`_.
 
-When submitting bug reports or questions via the `issue tracker 
-<https://github.com/lebedov/scikit-cuda/issues>`_, please include the following 
+When submitting bug reports or questions via the `issue tracker
+<https://github.com/lebedov/scikit-cuda/issues>`_, please include the following
 information:
 
 - Python version.
@@ -71,9 +71,9 @@ If you use scikit-cuda in a scholarly publication, please cite it as follows: ::
                         Jan Schl\"{u}ter and
                         Brian Thomas and
                         Chris Capdevila and
-                        Alex Rubinsteyn and 
+                        Alex Rubinsteyn and
                         Michael M. Forbes and
-                        Jacob Frelinger and 
+                        Jacob Frelinger and
                         Tim Klein and
                         Bruce Merry and
                         Nate Merill and
@@ -107,7 +107,7 @@ As of 2021, the CULA toolkit by `EM Photonics <https://emphotonics.com/>`_ no lo
 
 Related
 -------
-Python wrappers for `cuDNN <https://developer.nvidia.com/cudnn>`_ by Hannes 
+Python wrappers for `cuDNN <https://developer.nvidia.com/cudnn>`_ by Hannes
 Bretschneider are available `here
 <https://github.com/hannes-brt/cudnn-python-wrappers>`_.
 

--- a/demos/magma/demo_ssyedx_m.py
+++ b/demos/magma/demo_ssyedx_m.py
@@ -1,5 +1,5 @@
 """
-Demo of using ssyedx_m 
+Demo of using ssyedx_m
 """
 import numpy as np
 from skcuda import magma
@@ -56,11 +56,11 @@ def eigs(a_gpu, k=None, which='LM', imag=False, return_eigenvectors=True):
 
     if t == 's':
         status = magma.magma_ssyevdx_m(ngpu, jobz, rnge, uplo, N, a_gpu.ctypes.data, N,
-                                    vl, vu, il, iu, m, 
+                                    vl, vu, il, iu, m,
                                     w_gpu.ctypes.data, work.ctypes.data, lwork, iwork.ctypes.data, liwork)
     elif t == 'd':
         status = magma.magma_dsyevdx_m(ngpu, jobz, rnge, uplo, N, a_gpu.ctypes.data, N,
-                                    vl, vu, il, iu, m, 
+                                    vl, vu, il, iu, m,
                                     w_gpu.ctypes.data, work.ctypes.data, lwork, iwork.ctypes.data, liwork)
     else:
         raise ValueError('unsupported type')
@@ -81,10 +81,10 @@ if __name__=='__main__':
     N = int(sys.argv[1])
 
     # not symmetric, but only side of the diagonal is used
-    M_gpu = np.random.random((N, N)) 
+    M_gpu = np.random.random((N, N))
     M_gpu = M_gpu.astype(np.float32)
     M_cpu = M_gpu.copy()
-    
+
     # GPU
     t1 = time.time()
     W_gpu, V_gpu = eigs(M_gpu)

--- a/demos/magma/demo_ssyevdx_m.py
+++ b/demos/magma/demo_ssyevdx_m.py
@@ -1,5 +1,5 @@
 """
-Demo of using ssyedx_m 
+Demo of using ssyedx_m
 """
 import numpy as np
 from skcuda import magma
@@ -57,12 +57,12 @@ def eigs(a_gpu, k=None, which='LM', imag=False, return_eigenvectors=True):
     if t == 's':
         status = magma.magma_ssyevdx_m(ngpu, jobz, rnge, uplo, N, a_gpu.ctypes.data, N,
                                     vl, vu, il, iu,
-                                    m.ctypes.data, 
+                                    m.ctypes.data,
                                     w_gpu.ctypes.data, work.ctypes.data, lwork, iwork.ctypes.data, liwork)
     elif t == 'd':
         status = magma.magma_dsyevdx_m(ngpu, jobz, rnge, uplo, N, a_gpu.ctypes.data, N,
                                     vl, vu, il, iu,
-                                    m.ctypes.data,  
+                                    m.ctypes.data,
                                     w_gpu.ctypes.data, work.ctypes.data, lwork, iwork.ctypes.data, liwork)
     else:
         raise ValueError('unsupported type')
@@ -86,10 +86,10 @@ if __name__=='__main__':
     N = int(sys.argv[1])
 
     # not symmetric, but only side of the diagonal is used
-    M_gpu = np.random.random((N, N)) 
+    M_gpu = np.random.random((N, N))
     M_gpu = M_gpu.astype(np.float32)
     M_cpu = M_gpu.copy()
-    
+
     # GPU
     t1 = time.time()
     W_gpu, V_gpu = eigs(M_gpu, k=10)

--- a/demos/magma/demo_symmetric_eig.py
+++ b/demos/magma/demo_symmetric_eig.py
@@ -23,7 +23,7 @@ typedict = {'s': np.float32, 'd': np.float64, 'c': np.complex64, 'z': np.complex
 typedict_= {v: k for k, v in typedict.items()}
 
 def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
-    """A simple test of the eigenvalue solver for symmetric matrix. 
+    """A simple test of the eigenvalue solver for symmetric matrix.
     Random matrix is used.
 
     :param N: size of the testing matrix
@@ -46,7 +46,7 @@ def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
             print("Imported pycuda.gpuarray")
         except:
             raise ImportError("Cannot import pycuda.gpuarray!")
-    
+
     dtype = typedict[type_key]
     if dtype in [np.complex64, np.complex128]:
         raise ValueError("Complex types are not supported yet.")
@@ -55,8 +55,8 @@ def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
     np.random.seed(1234)
     M = np.random.random((N, N)).astype(dtype)
     M_cpu = M.copy() # for comparison
-    
-    # GPU 
+
+    # GPU
     jobz = 'N' # do not compute eigenvectors
     uplo = 'U' # use upper diagonal
     if expert:
@@ -64,7 +64,7 @@ def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
         vl = 0; vu = 1e10
         if keigs is None:
             keigs = int(np.ceil(N/2))
-        il = 1; iu = keigs; 
+        il = 1; iu = keigs;
         m = np.zeros((1,), dtype=int) # no. of eigenvalues found
 
     # allocate memory for eigenvalues
@@ -119,7 +119,7 @@ def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
         if 'x' in magma_function.__name__:
             # expert
             status = magma_function(ngpu, jobz, rnge, uplo, N, M.ctypes.data, N,
-                                    vl, vu, il, iu, m.ctypes.data, 
+                                    vl, vu, il, iu, m.ctypes.data,
                                     w_gpu.ctypes.data, work.ctypes.data, lwork, iwork.ctypes.data, liwork)
         else:
             # non-expert
@@ -131,7 +131,7 @@ def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
         M_gpu = gpuarray.to_gpu(M)
         if 'x' in magma_function.__name__:
             status = magma_function(jobz, rnge, uplo, N, M_gpu.gpudata, N,
-                                    vl, vu, il, iu, m.ctypes.data, 
+                                    vl, vu, il, iu, m.ctypes.data,
                                     w_gpu.ctypes.data, worka.ctypes.data, ldwa,
                                     work.ctypes.data, lwork, iwork.ctypes.data, liwork)
         else:
@@ -143,7 +143,7 @@ def _test_syev(N, type_key, data_gpu=False, ngpu=1, expert=False, keigs=None):
         if 'x' in magma_function.__name__:
             # expert
             status = magma_function(jobz, rnge, uplo, N, M.ctypes.data, N,
-                                    vl, vu, il, iu, m.ctypes.data, 
+                                    vl, vu, il, iu, m.ctypes.data,
                                     w_gpu.ctypes.data, work.ctypes.data, lwork, iwork.ctypes.data, liwork)
         else:
             # non-expert
@@ -203,6 +203,6 @@ def main():
                     _test_syev(N=N, type_key=t, data_gpu=True,
                                 ngpu=1, expert=expert)
     magma_finalize()
-   
+
 if __name__=='__main__':
     main()

--- a/demos/pca_demo.py
+++ b/demos/pca_demo.py
@@ -5,7 +5,7 @@ import pycuda.gpuarray as gpuarray
 import numpy as np
 import skcuda.linalg as linalg
 from skcuda.linalg import PCA as cuPCA
-from matplotlib import pyplot as plt 
+from matplotlib import pyplot as plt
 from sklearn import datasets
 
 iris = datasets.load_iris()
@@ -29,25 +29,25 @@ for i in range(len(demo_types)):
     demo_type = demo_types[i]
 
     # 1000 samples of 4-dimensional data vectors
-    X = X_orig.astype(demo_type) 
+    X = X_orig.astype(demo_type)
 
     X_gpu = gpuarray.to_gpu(X) # copy data to gpu
 
     T_gpu = pca.fit_transform(X_gpu) # calculate the principal components
 
-    # show that the resulting eigenvectors are orthogonal 
-    # Note that GPUArray.copy() is necessary to create a contiguous array 
+    # show that the resulting eigenvectors are orthogonal
+    # Note that GPUArray.copy() is necessary to create a contiguous array
     # from the array slice, otherwise there will be undefined behavior
-    dot_product = linalg.dot(T_gpu[:,0].copy(), T_gpu[:,1].copy()) 	
+    dot_product = linalg.dot(T_gpu[:,0].copy(), T_gpu[:,1].copy())
     T = T_gpu.get()
 
-    print("The dot product of the first two " + str(precisions[i]) + 
+    print("The dot product of the first two " + str(precisions[i]) +
             " precision eigenvectors is: " + str(dot_product))
-    
+
     # now get the variance of the eigenvectors and create the ratio explained from the total
     std_vec = np.std(T, axis=0)
-    print("We explained " + str(100 * np.sum(std_vec[:2]) / np.sum(std_vec)) + 
-            "% of the variance with 2 principal components in " +  
+    print("We explained " + str(100 * np.sum(std_vec[:2]) / np.sum(std_vec)) +
+            "% of the variance with 2 principal components in " +
             str(precisions[i]) +  " precision\n\n")
 
     # Plot results for double precision

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -2,22 +2,22 @@
 
 Authors & Acknowledgments
 =========================
-This software was written and packaged by `Lev Givon 
+This software was written and packaged by `Lev Givon
 <http://www.columbia.edu/~lev/>`_.  Although it
-depends upon the excellent `PyCUDA <http://mathema.tician.de/software/pycuda/>`_ 
-package by `Andreas Klöckner <http://mathema.tician.de/aboutme/>`_, scikit-cuda 
+depends upon the excellent `PyCUDA <http://mathema.tician.de/software/pycuda/>`_
+package by `Andreas Klöckner <http://mathema.tician.de/aboutme/>`_, scikit-cuda
 is developed independently of PyCUDA.
 
 Special thanks are due to the following parties for their contributions:
 
 - `Frédéric Bastien <https://github.com/nouiz>`_ - CUBLAS version detection enhancements.
-- `Arnaud Bergeron <https://github.com/abergeron>`_ - Fix to prevent LANG from 
+- `Arnaud Bergeron <https://github.com/abergeron>`_ - Fix to prevent LANG from
   affecting objdump output.
-- `David Wei Chiang <https://github.com/davidweichiang>`_ - Improvements to 
+- `David Wei Chiang <https://github.com/davidweichiang>`_ - Improvements to
   vectorized functions, bug fixes.
 - `Sander Dieleman <https://github.com/benanne>`_ - CUBLAS 5 bindings.
 - `Chris Capdevila <https://github.com/capdevc>`_ - MacOS X library search fix.
-- `Ben Erichson <https://github.com/Benli11>`_ - QR decomposition, eigenvalue/eigenvector computation, Dynamic 
+- `Ben Erichson <https://github.com/Benli11>`_ - QR decomposition, eigenvalue/eigenvector computation, Dynamic
   Mode Decomposition, randomized linear algebra routines.
 - `Ying Wei (Daniel) Fan
   <https://www.linkedin.com/pub/ying-wai-daniel-fan/5b/b8a/57>`_ - Kindly
@@ -25,19 +25,19 @@ Special thanks are due to the following parties for their contributions:
 - `Michael M. Forbes <https://github.com/mforbes>`_ - Improved MacOSX compatibility, bug fixes.
 - `Jacob Frelinger <https://github.com/jfrelinger>`_ - Various enhancements.
 - Tim Klein - Additional MAGMA wrappers.
-- `Joseph Martinot-Lagarde <https://github.com/Nodd>`_ - Python 3 compatibility 
+- `Joseph Martinot-Lagarde <https://github.com/Nodd>`_ - Python 3 compatibility
   improvements.
 - `Eric Larson <https://github.com/larsoner>`_ - Various enhancements.
 - `Gregory R. Lee <https://github.com/grlee77>`_ - Enhanced FFT plan creation.
-- `Bryant Menn <https://github.com/bmenn>`_ - CUSOLVER support for symmetric 
+- `Bryant Menn <https://github.com/bmenn>`_ - CUSOLVER support for symmetric
   eigenvalue decomposition.
-- `Bruce Merry <https://github.com/bmerry>`_ - Support for CUFFT extensible plan 
+- `Bruce Merry <https://github.com/bmerry>`_ - Support for CUFFT extensible plan
   API.
-- `Teodor Mihai Moldovan <https://github.com/teodor-moldovan>`_ - CUBLAS 5 
+- `Teodor Mihai Moldovan <https://github.com/teodor-moldovan>`_ - CUBLAS 5
   bindings.
 - `Lars Pastewka <https://github.com/pastewka>`_ - FFT tests and FFTW compatibility mode configuration.
 - `Li Yong Liu <http://laoniu85.github.io>`_ - CUBLAS batch wrappers.
-- `Luke Pfister <https://www.linkedin.com/pub/luke-pfister/11/70a/731>`_ - Bug 
+- `Luke Pfister <https://www.linkedin.com/pub/luke-pfister/11/70a/731>`_ - Bug
   fixes.
 - `Michael Rader <https://github.com/mrader1248>`_ - Bug fixes.
 - `Nate Merrill <https://github.com/nmerrill67>`_ - PCA module.
@@ -51,9 +51,9 @@ Special thanks are due to the following parties for their contributions:
 - `Stefan van der Walt <https://github.com/stefanv>`_ - Bug fixes.
 - `Feng Wang <https://github.com/cnwangfeng>`_ - Bug reports.
 - `Alexander Weyman <https://github.com/AlexanderWeyman>`_ - Simpson's Rule.
-- `Evgeniy Zheltonozhskiy <https://github.com/randl>`_ - Complex Hermitian 
+- `Evgeniy Zheltonozhskiy <https://github.com/randl>`_ - Complex Hermitian
   support eigenvalue decomposition.
-- `Wing-Kit Lee <https://github.com/wingkitlee>`_ - Fixes for MAGMA eigenvalue 
+- `Wing-Kit Lee <https://github.com/wingkitlee>`_ - Fixes for MAGMA eigenvalue
   decomp wrappers.
-- `Yiyin Zhou <https://github.com/yiyin>`_ - Patches, bug reports, and function 
-  wrappers 
+- `Yiyin Zhou <https://github.com/yiyin>`_ - Patches, bug reports, and function
+  wrappers

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -14,7 +14,7 @@ Release 0.5.3 (May 26, 2019)
 * Add MAGMA GELS wrappers (#271).
 * Add context-dependent memoization to skcuda.fft and other modules (#273).
 * Fix issues finding CUDA libraries on Windows.
-  
+
 Release 0.5.2 (November 6, 2018)
 --------------------------------
 * Prevent exceptions when CULA Dense free is present (#146).
@@ -39,11 +39,11 @@ Release 0.5.2 (November 6, 2018)
 * Skip CULA-dependent unit tests when CULA isn't present.
 * CUSOLVER support for symmetric eigenvalue decomposition (enh. by Bryant Menn).
 * CUSOLVER support for matrix inversion, QR decomposition (#198).
-* Prevent objdump output from changing due to environment language (fix by 
+* Prevent objdump output from changing due to environment language (fix by
   Arnaud Bergeron).
 * Fix diag() support for column-major 2D array inputs (#219).
 * Use absolute path for skcuda header includes (enh. by S. Clarkson).
-* Fix QR issues by reverting fix for #131 and raising PyCUDA version requirement 
+* Fix QR issues by reverting fix for #131 and raising PyCUDA version requirement
   (fix by S. Clarkson).
 * More batch CUBLAS wrappers (enh. by Li Yong Liu)
 * Numerical integration with Simpson's Rule (enh. by Alexander Weyman)
@@ -63,7 +63,7 @@ Release 0.5.1 - (October 30, 2015)
 * Standard and randomized Dynamic Mode Decomposition (enh. by N. Benjamin Erichson).
 * Randomized linear algebra routines (enh. by N. Benjamin Erichson).
 * Add triu function (enh. by N. Benjamin Erichson).
-* Support Bessel correction in computation of variance and standard 
+* Support Bessel correction in computation of variance and standard
   deviation (#143).
 * Fix pip installation issues.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -243,12 +243,12 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-'preamble': """
+'preamble': r"""
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}
 \usepackage{ucs}
-\\renewcommand{\\familydefault}{\\sfdefault}
+\renewcommand{\familydefault}{\sfdefault}
 """
 }
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,7 @@ not already on your system.
 
 Obtaining the Latest Software
 -----------------------------
-The latest stable and development versions of ``scikit-cuda`` can be downloaded 
+The latest stable and development versions of ``scikit-cuda`` can be downloaded
 from `GitHub <https://github.com/lebedov/scikit-cuda>`_
 
 Online documentation is available at `<https://scikit-cuda.readthedocs.org>`_
@@ -32,12 +32,12 @@ installed:
 * `NumPy <http://www.numpy.org>`_ 1.2.0 or later.
 * `PyCUDA <http://mathema.tician.de/software/pycuda>`_ 2016.1 or later (some
   parts of ``scikit-cuda`` might not work properly with earlier versions).
-* `NVIDIA CUDA Toolkit <http://www.nvidia.com/object/cuda_home_new.html>`_ 5.0 
+* `NVIDIA CUDA Toolkit <http://www.nvidia.com/object/cuda_home_new.html>`_ 5.0
   or later.
 
-Note that both Python and the CUDA Toolkit must be built for the same 
-architecture, i.e., Python compiled for a 32-bit architecture will not find the 
-libraries provided by a 64-bit CUDA installation. CUDA versions from 7.0 onwards 
+Note that both Python and the CUDA Toolkit must be built for the same
+architecture, i.e., Python compiled for a 32-bit architecture will not find the
+libraries provided by a 64-bit CUDA installation. CUDA versions from 7.0 onwards
 are 64-bit.
 
 To run the unit tests, the following packages are also required:
@@ -70,13 +70,13 @@ Building and Installation
 -------------------------
 ``scikit-cuda`` searches for CUDA libraries in the system library
 search path when imported. You may have to modify this path (e.g., by adding the
-path to the CUDA libraries to ``/etc/ld.so.conf`` and running ``ldconfig`` as 
+path to the CUDA libraries to ``/etc/ld.so.conf`` and running ``ldconfig`` as
 root or to the
-``LD_LIBRARY_PATH`` environmental variable on Linux, or by adding the CUDA 
+``LD_LIBRARY_PATH`` environmental variable on Linux, or by adding the CUDA
 library path to the ``DYLD_LIBRARY_PATH`` on MacOSX) if the libraries are
 not being found.
 
-To build and install the toolbox, download and unpack the source 
+To build and install the toolbox, download and unpack the source
 release and run::
 
    python setup.py install

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -19,7 +19,7 @@ High-Level Routines
 .. toctree::
    :maxdepth: 2
 
-   reference_fft   
+   reference_fft
    reference_integrate
    reference_linalg
    reference_rlinalg

--- a/docs/source/reference_cublas.rst
+++ b/docs/source/reference_cublas.rst
@@ -19,7 +19,7 @@ Helper Routines
    cublasGetVersion
    cublasSetPointerMode
    cublasSetStream
-   
+
 Wrapper Routines
 ----------------
 
@@ -81,7 +81,7 @@ Double Precision BLAS1 Routines
    cublasDznrm2
    cublasIzamax
    cublasIzamin
-   
+
    cublasZaxpy
    cublasZcopy
    cublasZdotc

--- a/docs/source/reference_cufft.rst
+++ b/docs/source/reference_cufft.rst
@@ -24,7 +24,7 @@ Wrapper Routines
 .. autosummary::
     :toctree: generated/
     :nosignatures:
-    
+
     cufftPlan1d
     cufftPlan2d
     cufftPlan3d

--- a/docs/source/reference_cula.rst
+++ b/docs/source/reference_cula.rst
@@ -77,7 +77,7 @@ Double Precision Complex
    culaDeviceZgeTransposeConjugate
    culaDeviceZgeTransposeInplace
    culaDeviceZgeTransposeConjugateInplace
-    
+
 BLAS Routines
 -------------
 
@@ -134,7 +134,7 @@ Single Precision Real
    culaDeviceSgglse
    culaDeviceSposv
    culaDeviceSpotrf
-   
+
 Single Precision Complex
 ^^^^^^^^^^^^^^^^^^^^^^^^
 .. autosummary::

--- a/docs/source/reference_fft.rst
+++ b/docs/source/reference_fft.rst
@@ -11,4 +11,4 @@ Fast Fourier Transform
    fft
    ifft
    Plan
-   
+

--- a/skcuda/cublas.py
+++ b/skcuda/cublas.py
@@ -257,9 +257,9 @@ def _get_cublas_version():
     """
     Get and save CUBLAS version using the CUBLAS library's SONAME.
 
-    This function tries to avoid calling cublasGetVersion because creating a 
-    CUBLAS context can subtly affect the performance of subsequent 
-    CUDA operations in certain circumstances. 
+    This function tries to avoid calling cublasGetVersion because creating a
+    CUBLAS context can subtly affect the performance of subsequent
+    CUDA operations in certain circumstances.
 
     Results
     -------
@@ -2644,7 +2644,7 @@ def cublasZgerc(handle, m, n, alpha, x, incx, y, incy, A, lda):
 
     References
     ----------
-    `cublas<t>ger <http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-ger>`_    
+    `cublas<t>ger <http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-ger>`_
     """
 
     status = _libcublas.cublasZgerc_v2(handle,

--- a/skcuda/cula.py
+++ b/skcuda/cula.py
@@ -499,7 +499,7 @@ except AttributeError:
         """
         QR factorization - Generate Q from QR factorization
         """
-        
+
         raise NotImplementedError('CULA Dense required')
 else:
     def culaDeviceSorgqr(m, n, k, a, lda, tau):
@@ -1489,7 +1489,7 @@ def culaDeviceZgemv(trans, m, n, alpha, A, lda, x, incx, beta, y, incy):
                                                beta.imag),
                            int(y), incy)
     culaCheckStatus(status)
-    
+
 # SGEEV, DGEEV, CGEEV, ZGEEV
 try:
     _libcula.culaDeviceSgeev.restype = \
@@ -1591,8 +1591,8 @@ else:
         jobvr = jobvr.encode('ascii')
         status = _libcula.culaDeviceZgeev(jobvl, jobvr, n, int(a), lda, int(w),
                                int(vl), ldvl, int(vr), ldvr)
-        culaCheckStatus(status)   
-    
+        culaCheckStatus(status)
+
 # Auxiliary routines:
 
 try:

--- a/skcuda/cusparse.py
+++ b/skcuda/cusparse.py
@@ -299,7 +299,7 @@ def cusparseSetMatType(desc, type):
     cusparseCheckStatus(status)
 
 _libcusparse.cusparseGetMatType.restype = int
-_libcusparse.cusparseGetMatType.argtypes = [cusparseMatDescr]    
+_libcusparse.cusparseGetMatType.argtypes = [cusparseMatDescr]
 def cusparseGetMatType(desc):
     """
     Gets the matrix type of the specified matrix.
@@ -329,7 +329,7 @@ _libcusparse.cusparseSnnz.argtypes = [ctypes.c_int,
                                       ctypes.c_int,
                                       ctypes.c_void_p,
                                       ctypes.c_void_p]
-def cusparseSnnz(handle, dirA, m, n, descrA, A, lda, 
+def cusparseSnnz(handle, dirA, m, n, descrA, A, lda,
                  nnzPerRowColumn, nnzTotalDevHostPtr):
     """
     Compute number of non-zero elements per row, column, or dense matrix.
@@ -350,11 +350,11 @@ def cusparseSnnz(handle, dirA, m, n, descrA, A, lda,
         Dense matrix of dimensions (lda, n).
     lda : int
         Leading dimension of A.
-    
+
     Returns
     -------
     nnzPerRowColumn : pycuda.gpuarray.GPUArray
-        Array of length m or n containing the number of 
+        Array of length m or n containing the number of
         non-zero elements per row or column, respectively.
     nnzTotalDevHostPtr : pycuda.gpuarray.GPUArray
         Total number of non-zero elements in device or host memory.
@@ -365,7 +365,7 @@ def cusparseSnnz(handle, dirA, m, n, descrA, A, lda,
     nnzPerRowColumn = gpuarray.empty()
     nnzTotalDevHostPtr = gpuarray.empty()
 
-    status = _libcusparse.cusparseSnnz(handle, dirA, m, n, 
+    status = _libcusparse.cusparseSnnz(handle, dirA, m, n,
                                        descrA, int(A), lda,
                                        int(nnzPerRowColumn), int(nnzTotalDevHostPtr))
     cusparseCheckStatus(status)
@@ -382,7 +382,7 @@ _libcusparse.cusparseSdense2csr.argtypes = [ctypes.c_int,
                                             ctypes.c_void_p,
                                             ctypes.c_void_p,
                                             ctypes.c_void_p]
-def cusparseSdense2csr(handle, m, n, descrA, A, lda, 
+def cusparseSdense2csr(handle, m, n, descrA, A, lda,
                        nnzPerRow, csrValA, csrRowPtrA, csrColIndA):
     # Unfinished
     pass

--- a/skcuda/integrate.py
+++ b/skcuda/integrate.py
@@ -117,8 +117,8 @@ def gen_simps_mult(N, dtype, even='avg'):
     length is equivalent to the definite integral of the latter
     computed using composite Simpson's rule.
 
-    If there are an even number of samples, N, then there are an odd 
-    number of intervals (N-1), but Simpson's rule requires an even number 
+    If there are an even number of samples, N, then there are an odd
+    number of intervals (N-1), but Simpson's rule requires an even number
     of intervals. The parameter 'even' controls how this is handled.
 
     Parameters
@@ -160,7 +160,7 @@ def gen_simps_mult(N, dtype, even='avg'):
             raise ValueError("Parameter 'even' must be "
                              "'avg', 'last', or 'first'.")
         basic_simps = gen_simps_mult(N-1, dtype)
-        
+
         if even in ['avg', 'first']:
             x_gpu[:-1] += basic_simps
             x_gpu[-2:] += 0.5 # trapz on last interval
@@ -173,12 +173,12 @@ def gen_simps_mult(N, dtype, even='avg'):
 
 def simps(x_gpu, dx=1.0, even='avg', handle=None):
     """
-    Implementation of composite Simpson's rule similar to 
+    Implementation of composite Simpson's rule similar to
     scipy.integrate.simps.
 
     Integrate x_gpu with spacing dx using composite Simpson's rule.
-    If there are an even number of samples, N, then there are an odd 
-    number of intervals (N-1), but Simpson's rule requires an even number 
+    If there are an even number of samples, N, then there are an odd
+    number of intervals (N-1), but Simpson's rule requires an even number
     of intervals. The parameter 'even' controls how this is handled.
 
     Parameters

--- a/skcuda/linalg.py
+++ b/skcuda/linalg.py
@@ -54,14 +54,14 @@ class PCA(object):
     """
     Principal Component Analysis with similar API to sklearn.decomposition.PCA
 
-    The algorithm implemented here was first implemented with cuda in [Andrecut, 2008]. 
+    The algorithm implemented here was first implemented with cuda in [Andrecut, 2008].
     It performs a linear dimensionality reduction for a data matrix, mapping the data
     to a lower dimensional space of dimension `n_components`. See references for more information.
 
     Parameters
     ----------
     n_components: int, default=None
-       The number of principal component column vectors to compute in the output 
+       The number of principal component column vectors to compute in the output
        matrix.
 
     epsilon: float, default=1e-7
@@ -86,15 +86,15 @@ class PCA(object):
     >>> import pycuda.gpuarray as gpuarray
     >>> import numpy as np
     >>> import skcuda.linalg as linalg
-    >>> from skcuda.linalg import PCA as cuPCA 
+    >>> from skcuda.linalg import PCA as cuPCA
     >>> pca = cuPCA(n_components=4) # map the data to 4 dimensions
     >>> X = np.random.rand(1000,100) # 1000 samples of 100-dimensional data vectors
     >>> X_gpu = gpuarray.to_gpu(X) # copy data to gpu
     >>> T_gpu = pca.fit_transform(X_gpu) # calculate the principal components
     >>> linalg.dot(T_gpu[:,0].copy(), T_gpu[:,1].copy()) # show that the resulting eigenvectors are orthogonal (dot should be close to 0)
     -2.220446049250313e-16
-    >>> 
-    >>> X_gpu_trans = gpuarray.to_gpu(X.T.copy()) # use transposed_input 
+    >>>
+    >>> X_gpu_trans = gpuarray.to_gpu(X.T.copy()) # use transposed_input
     >>> T_gpu_trans = pca.fit_transform(X_gpu_trans, transposed_input=True)
     >>> linalg.dot(T_gpu_trans[0,:], T_gpu_trans[1,:]) # No need to copy since rows are contiguous
     -2.220446049250313e-16
@@ -122,7 +122,7 @@ class PCA(object):
         X_gpu: pycuda.gpuarray.GPUArray
             C-ordered data matrix of shape `[N P]` (N = number of samples, P = number of variables)
             that needs to be reduced. X_gpu can be of type `numpy.float32` or `numpy.float64`.
-        
+
         transposed_input: bool
             If set to `True`, then `X_gpu` must be shaped as `[P N]` and still be C-ordered.
             The benefit of this is to avoid copying the underlying data to column-major
@@ -131,7 +131,7 @@ class PCA(object):
         Returns
         -------
         T_gpu: pycuda.gpuarray.GPUArray
-            `[N n_components]` matrix of the first `n_components` principal components of `X_gpu`. 
+            `[N n_components]` matrix of the first `n_components` principal components of `X_gpu`.
             If `transposed_input` is `True`, then `T_gpu` will be of shape `[n_components N]`.
 
         References
@@ -140,7 +140,7 @@ class PCA(object):
 
         Notes
         -----
-        If n_components was not set, then `n_components = min(N, P)`. 
+        If n_components was not set, then `n_components = min(N, P)`.
         Otherwise, `n_components = min(n_components, N, P)`
 
         Examples
@@ -149,15 +149,15 @@ class PCA(object):
         >>> import pycuda.gpuarray as gpuarray
         >>> import numpy as np
         >>> import skcuda.linalg as linalg
-        >>> from skcuda.linalg import PCA as cuPCA 
+        >>> from skcuda.linalg import PCA as cuPCA
         >>> pca = cuPCA(n_components=4) # map the data to 4 dimensions
         >>> X = np.random.rand(1000,100) # 1000 samples of 100-dimensional data vectors
         >>> X_gpu = gpuarray.to_gpu(X) # copy data to gpu
         >>> T_gpu = pca.fit_transform(X_gpu) # calculate the principal components
         >>> linalg.dot(T_gpu[:,0].copy(), T_gpu[:,1].copy()) # show that the resulting eigenvectors are orthogonal (dot should be close to 0)
         -2.220446049250313e-16
-        >>> 
-        >>> X_gpu_trans = gpuarray.to_gpu(X.T.copy()) # use transposed_input 
+        >>>
+        >>> X_gpu_trans = gpuarray.to_gpu(X.T.copy()) # use transposed_input
         >>> T_gpu_trans = pca.fit_transform(X_gpu_trans, transposed_input=True)
         >>> linalg.dot(T_gpu_trans[0,:], T_gpu_trans[1,:]) # No need to copy since rows are contiguous
         -2.220446049250313e-16
@@ -193,7 +193,7 @@ class PCA(object):
             cuGer = cublas.cublasDger
         else:
             raise TypeError("Array must be of type numpy.float32 or numpy.float64, not '" +
-                    str(X_gpu.dtype) + "'") 
+                    str(X_gpu.dtype) + "'")
 
         n_components = self.n_components
         if n_components is None or n_components > n or n_components > p:
@@ -208,7 +208,7 @@ class PCA(object):
             R_gpu = gpuarray.empty((p,n), inpt_dtype)
             for i in range(p):
                 cuCopy(self.h, n, X_gpu[:,i].gpudata, p, R_gpu[i,:].gpudata, 1)
-            
+
         Lambda = np.zeros((n_components,1), inpt_dtype) # kx1
         P_gpu = gpuarray.zeros((n_components, p), inpt_dtype) # pxk^T
         T_gpu = gpuarray.zeros((n_components, n), inpt_dtype) # nxk^T
@@ -225,20 +225,20 @@ class PCA(object):
             mu = 0.0
             cuCopy(self.h, n, R_gpu[k,:].gpudata, 1, T_gpu[k,:].gpudata, 1)
             for j in range(self.max_iter):
-                cuGemv(self.h, 't', n, p, 1.0, R_gpu.gpudata, n, T_gpu[k,:].gpudata, 
+                cuGemv(self.h, 't', n, p, 1.0, R_gpu.gpudata, n, T_gpu[k,:].gpudata,
                         1, 0.0, P_gpu[k,:].gpudata, 1)
                 if k > 0:
                     cuGemv(self.h,'t', p, k, 1.0, P_gpu.gpudata, p, P_gpu[k,:].gpudata,
-                            1, 0.0, U_gpu.gpudata, 1)  
-                    cuGemv (self.h, 'n', p, k, -1.0, P_gpu.gpudata, p, U_gpu.gpudata, 
+                            1, 0.0, U_gpu.gpudata, 1)
+                    cuGemv (self.h, 'n', p, k, -1.0, P_gpu.gpudata, p, U_gpu.gpudata,
                             1, 1.0, P_gpu[k,:].gpudata, 1)
 
                 l2 = cuNrm2(self.h, p, P_gpu[k,:].gpudata, 1)
                 cuScal(self.h, p, 1.0/l2, P_gpu[k,:].gpudata, 1)
-                cuGemv(self.h, 'n', n, p, 1.0, R_gpu.gpudata, n, P_gpu[k,:].gpudata, 
+                cuGemv(self.h, 'n', n, p, 1.0, R_gpu.gpudata, n, P_gpu[k,:].gpudata,
                         1, 0.0, T_gpu[k,:].gpudata, 1)
                 if k > 0:
-                    cuGemv(self.h, 't', n, k, 1.0, T_gpu.gpudata, n, T_gpu[k,:].gpudata, 
+                    cuGemv(self.h, 't', n, k, 1.0, T_gpu.gpudata, n, T_gpu[k,:].gpudata,
                             1, 0.0, U_gpu.gpudata, 1)
                     cuGemv(self.h, 'n', n, k, -1.0, T_gpu.gpudata, n, U_gpu.gpudata,
                             1, 1.0, T_gpu[k,:].gpudata, 1)
@@ -256,7 +256,7 @@ class PCA(object):
 
         # last step is to multiply each component vector by the corresponding eigenvalue
         for k in range(n_components):
-            cuScal(self.h, n, Lambda[k], T_gpu[k,:].gpudata, 1) 
+            cuScal(self.h, n, Lambda[k], T_gpu[k,:].gpudata, 1)
 
         if transposed_input:
             return T_gpu
@@ -276,7 +276,7 @@ class PCA(object):
         ----------
 
         n_components: int
-            The new number of principal components to return in fit_transform. 
+            The new number of principal components to return in fit_transform.
             Must be None or greater than 0
         """
 
@@ -2268,7 +2268,7 @@ def inv(a_gpu, overwrite=False, ipiv_gpu=None, lib='cusolver'):
             Lwork = bufsize(misc._global_cusolver_handle, n, n, in_gpu.gpudata, n)
             Work = gpuarray.empty(Lwork, data_dtype, allocator=alloc)
             devInfo = gpuarray.empty(1, np.int32, allocator=alloc)
-            getrf(misc._global_cusolver_handle, n, n, in_gpu.gpudata, n, 
+            getrf(misc._global_cusolver_handle, n, n, in_gpu.gpudata, n,
                   Work.gpudata, ipiv_gpu.gpudata, devInfo.gpudata)
         except cusolver.CUSOLVER_ERROR as e:
             raise LinAlgError(e)
@@ -2637,7 +2637,7 @@ def qr(a_gpu, mode='reduced', handle=None, lib='cusolver'):
     if lib == 'cula':
         func_qr(m, n, int(a_gpu.gpudata), lda, int(tau_gpu.gpudata))
     else:
-        Lwork = bufsize_qr(cusolverHandle, m, n, int(a_gpu.gpudata), m)      
+        Lwork = bufsize_qr(cusolverHandle, m, n, int(a_gpu.gpudata), m)
         workspace_gpu = gpuarray.empty(Lwork, data_type, allocator=alloc)
         devInfo = gpuarray.empty(1, np.int32, allocator=alloc)
         func_qr(cusolverHandle, m, n, int(a_gpu.gpudata), lda, int(tau_gpu.gpudata),
@@ -2934,13 +2934,13 @@ def _get_vander_kernel(use_double, use_complex, rows, cols):
 
      __global__ void vander(FLOAT *a, FLOAT *b, int m, int n) {
 
-	  unsigned int ix;
-	  unsigned int r = blockIdx.x*blockDim.x+threadIdx.x;
+          unsigned int ix;
+          unsigned int r = blockIdx.x*blockDim.x+threadIdx.x;
 
-	  if(r < m) {
-	    for(int i=1; i<n; ++i) {
-	       ix = r  + m*i  ;
-	       a[ix] = a[r  + m*(i-1)] * b[r];
+          if(r < m) {
+            for(int i=1; i<n; ++i) {
+               ix = r  + m*i  ;
+               a[ix] = a[r  + m*(i-1)] * b[r];
             }
           }
      }

--- a/skcuda/magma.py
+++ b/skcuda/magma.py
@@ -1235,7 +1235,7 @@ def magma_zgesvd_buffersize(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt):
 def _magma_gels_buffersize(trans, m, n, nrhs, a, lda, b, ldb, func, dtype):
     work = np.zeros(1, dtype)
     func(trans, m, n, nrhs,
-         int(a), lda, int(b), ldb, 
+         int(a), lda, int(b), ldb,
          int(work.ctypes.data), -1)
     return int(work[0])
 
@@ -1569,7 +1569,7 @@ def magma_cgeqrf(m, n, A, lda, tau, work, lwork):
     """
     QR factorization.
     """
-    
+
     info = c_int_type()
     status = _libmagma.magma_cgeqrf(m, n, int(A), lda,
                                     int(tau), int(work),
@@ -1585,11 +1585,11 @@ _libmagma.magma_zgeqrf.argtypes = [c_int_type,
                                    ctypes.c_void_p,
                                    c_int_type,
                                    ctypes.c_void_p]
-def magma_zgeqrf(m, n, A, lda, tau, work, lwork):  
+def magma_zgeqrf(m, n, A, lda, tau, work, lwork):
     """
     QR factorization.
     """
-    
+
     info = c_int_type()
     status = _libmagma.magma_zgeqrf(m, n, int(A), lda,
                                     int(tau), int(work),
@@ -3771,13 +3771,13 @@ def magma_ssyevdx(jobz, rnge, uplo, n, A, lda,
     """
 
     # _XXX_conversion[] returns integer according to magma_types.h
-    jobz = _vec_conversion[jobz] 
+    jobz = _vec_conversion[jobz]
     rnge = _range_conversion[rnge]
     uplo = _uplo_conversion[uplo]
     info = c_int_type()
     status = _libmagma.magma_ssyevdx(jobz, rnge, uplo, n, int(A), lda,
                                         vl, vu, il, iu, int(m),
-                                        int(w), int(work), lwork, int(iwork), liwork, 
+                                        int(w), int(work), lwork, int(iwork), liwork,
                                         ctypes.byref(info))
     magmaCheckStatus(status)
 
@@ -3791,13 +3791,13 @@ def magma_dsyevdx(jobz, rnge, uplo, n, A, lda,
     Multi-GPU, data on host, expert mode
     """
     # _XXX_conversion[] returns integer according to magma_types.h
-    jobz = _vec_conversion[jobz] 
+    jobz = _vec_conversion[jobz]
     rnge = _range_conversion[rnge]
     uplo = _uplo_conversion[uplo]
     info = c_int_type()
     status = _libmagma.magma_dsyevdx(jobz, rnge, uplo, n, int(A), lda,
-                                        vl, vu, il, iu, int(m), 
-                                        int(w), int(work), lwork, int(iwork), liwork, 
+                                        vl, vu, il, iu, int(m),
+                                        int(w), int(work), lwork, int(iwork), liwork,
                                         ctypes.byref(info))
     magmaCheckStatus(status)
 
@@ -3831,13 +3831,13 @@ def magma_ssyevdx_m(ngpu, jobz, rnge, uplo, n, A, lda,
     source: ssyedx_m.cpp
     """
     # _XXX_conversion[] returns integer according to magma_types.h
-    jobz = _vec_conversion[jobz] 
+    jobz = _vec_conversion[jobz]
     rnge = _range_conversion[rnge]
     uplo = _uplo_conversion[uplo]
     info = c_int_type()
     status = _libmagma.magma_ssyevdx_m(ngpu, jobz, rnge, uplo, n, int(A), lda,
                                         vl, vu, il, iu, int(m),
-                                        int(w), int(work), lwork, int(iwork), liwork, 
+                                        int(w), int(work), lwork, int(iwork), liwork,
                                         ctypes.byref(info))
     magmaCheckStatus(status)
 
@@ -3853,13 +3853,13 @@ def magma_dsyevdx_m(ngpu, jobz, rnge, uplo, n, A, lda,
     source: dsyedx_m.cpp
     """
     # _XXX_conversion[] returns integer according to magma_types.h
-    jobz = _vec_conversion[jobz] 
+    jobz = _vec_conversion[jobz]
     rnge = _range_conversion[rnge]
     uplo = _uplo_conversion[uplo]
     info = c_int_type()
     status = _libmagma.magma_dsyevdx_m(ngpu, jobz, rnge, uplo, n, int(A), lda,
                                         vl, vu, il, iu, int(m),
-                                        int(w), int(work), lwork, int(iwork), liwork, 
+                                        int(w), int(work), lwork, int(iwork), liwork,
                                         ctypes.byref(info))
     magmaCheckStatus(status)
 
@@ -3886,7 +3886,7 @@ _libmagma.magma_ssyevdx_gpu.argtypes = [c_int_type,     # jobz
                                         ctypes.c_void_p]# info
 def magma_ssyevdx_gpu(jobz, rnge, uplo, n, A, lda,
                     vl, vu, il, iu, m,
-                    w, wa, ldwa, 
+                    w, wa, ldwa,
                     work, lwork, iwork, liwork):
     """
     Compute eigenvalues of real symmetric matrix.
@@ -3895,14 +3895,14 @@ def magma_ssyevdx_gpu(jobz, rnge, uplo, n, A, lda,
     source: dsyedx_m.cpp
     """
     # _XXX_conversion[] returns integer according to magma_types.h
-    jobz = _vec_conversion[jobz] 
+    jobz = _vec_conversion[jobz]
     rnge = _range_conversion[rnge]
     uplo = _uplo_conversion[uplo]
     info = c_int_type()
     status = _libmagma.magma_ssyevdx_gpu(jobz, rnge, uplo, n, int(A), lda,
                                         vl, vu, il, iu, int(m),
                                         int(w), int(wa), ldwa,
-                                        int(work), lwork, int(iwork), liwork, 
+                                        int(work), lwork, int(iwork), liwork,
                                         ctypes.byref(info))
     magmaCheckStatus(status)
 
@@ -3910,7 +3910,7 @@ _libmagma.magma_dsyevdx_gpu.restype = int
 _libmagma.magma_dsyevdx_gpu.argtypes = _libmagma.magma_ssyevdx_gpu.argtypes
 def magma_dsyevdx_gpu(jobz, rnge, uplo, n, A, lda,
                     vl, vu, il, iu, m,
-                    w, wa, ldwa, 
+                    w, wa, ldwa,
                     work, lwork, iwork, liwork):
     """
     Compute eigenvalues of real symmetric matrix.
@@ -3918,14 +3918,14 @@ def magma_dsyevdx_gpu(jobz, rnge, uplo, n, A, lda,
 
     source: dsyedx_m.cpp
     """
-    jobz = _vec_conversion[jobz] 
+    jobz = _vec_conversion[jobz]
     rnge = _range_conversion[rnge]
     uplo = _uplo_conversion[uplo]
     info = c_int_type()
     status = _libmagma.magma_dsyevdx_gpu(jobz, rnge, uplo, n, int(A), lda,
                                         vl, vu, il, iu, int(m),
                                         int(w), int(wa), ldwa,
-                                        int(work), lwork, int(iwork), liwork, 
+                                        int(work), lwork, int(iwork), liwork,
                                         ctypes.byref(info))
     magmaCheckStatus(status)
 

--- a/skcuda/misc.py
+++ b/skcuda/misc.py
@@ -152,7 +152,7 @@ def init(allocator=drv.mem_alloc):
     """
     Initialize libraries used by scikit-cuda.
 
-    Initialize the CUBLAS, CULA, CUSOLVER, and MAGMA libraries used by 
+    Initialize the CUBLAS, CULA, CUSOLVER, and MAGMA libraries used by
     high-level functions provided by scikit-cuda.
 
     Parameters
@@ -171,7 +171,7 @@ def init(allocator=drv.mem_alloc):
     if not _global_cublas_handle:
         from . import cublas  # nest to avoid requiring cublas e.g. for FFT
         _global_cublas_handle = cublas.cublasCreate()
-    
+
     if _global_cublas_allocator is None:
         _global_cublas_allocator = allocator
 
@@ -195,7 +195,7 @@ def shutdown():
     """
     Shutdown libraries used by scikit-cuda.
 
-    Shutdown the CUBLAS, CULA, CUSOLVER, and MAGMA libraries used by 
+    Shutdown the CUBLAS, CULA, CUSOLVER, and MAGMA libraries used by
     high-level functions provided by scikits-cuda.
 
     Notes
@@ -1320,7 +1320,7 @@ def var(x_gpu, ddof=0, axis=None, stream=None, keepdims=False):
     x_gpu : pycuda.gpuarray.GPUArray
         Array containing numbers whose variance is desired.
     ddof : int (optional)
-        "Delta Degrees of Freedom": the divisor used in computing the 
+        "Delta Degrees of Freedom": the divisor used in computing the
         variance is ``N - ddof``, where ``N`` is the number of elements.
         Setting ``ddof = 1`` is equivalent to applying Bessel's
         correction.
@@ -1373,7 +1373,7 @@ def std(x_gpu, ddof=0, axis=None, stream=None, keepdims=False):
     x_gpu : pycuda.gpuarray.GPUArray
         Array containing numbers whose std is desired.
     ddof : int (optional)
-        "Delta Degrees of Freedom": the divisor used in computing the 
+        "Delta Degrees of Freedom": the divisor used in computing the
         variance is ``N - ddof``, where ``N`` is the number of elements.
         Setting ``ddof = 1`` is equivalent to applying Bessel's
         correction.

--- a/skcuda/pcula.py
+++ b/skcuda/pcula.py
@@ -71,7 +71,7 @@ def pculaSgemm(config, transa, transb, m, n, k, alpha, A, lda, B, ldb,
 
     """
 
-    status = _libpcula.pculaSgemm(ctypes.byref(config), transa, transb, m, n, k, alpha, 
+    status = _libpcula.pculaSgemm(ctypes.byref(config), transa, transb, m, n, k, alpha,
                                   int(A), lda, int(B), ldb, beta, int(C), ldc)
     culaCheckStatus(status)
 
@@ -97,7 +97,7 @@ def pculaDgemm(config, transa, transb, m, n, k, alpha, A, lda, B, ldb,
 
     """
 
-    status = _libpcula.pculaDgemm(ctypes.byref(config), transa, transb, m, n, k, alpha, 
+    status = _libpcula.pculaDgemm(ctypes.byref(config), transa, transb, m, n, k, alpha,
                                   int(A), lda, int(B), ldb, beta, int(C), ldc)
     culaCheckStatus(status)
 
@@ -123,7 +123,7 @@ def pculaCgemm(config, transa, transb, m, n, k, alpha, A, lda, B, ldb,
 
     """
 
-    status = _libpcula.pculaCgemm(ctypes.byref(config), transa, transb, m, n, k, alpha, 
+    status = _libpcula.pculaCgemm(ctypes.byref(config), transa, transb, m, n, k, alpha,
                                   int(A), lda, int(B), ldb, beta, int(C), ldc)
     culaCheckStatus(status)
 
@@ -149,7 +149,7 @@ def pculaZgemm(config, transa, transb, m, n, k, alpha, A, lda, B, ldb,
 
     """
 
-    status = _libpcula.pculaZgemm(ctypes.byref(config), transa, transb, m, n, k, alpha, 
+    status = _libpcula.pculaZgemm(ctypes.byref(config), transa, transb, m, n, k, alpha,
                                   int(A), lda, int(B), ldb, beta, int(C), ldc)
     culaCheckStatus(status)
 
@@ -174,7 +174,7 @@ def pculaStrsm(config, side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb):
     """
 
     status = _libpcula.pculaStrsm(ctypes.byref(config), side, uplo, transa,
-                                  diag, m, n, alpha, int(a), lda, int(b), ldb)                                  
+                                  diag, m, n, alpha, int(a), lda, int(b), ldb)
     culaCheckStatus(status)
 
 _libpcula.pculaDtrsm.restype = int
@@ -197,7 +197,7 @@ def pculaDtrsm(config, side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb):
     """
 
     status = _libpcula.pculaDtrsm(ctypes.byref(config), side, uplo, transa,
-                                  diag, m, n, alpha, int(a), lda, int(b), ldb)                                  
+                                  diag, m, n, alpha, int(a), lda, int(b), ldb)
     culaCheckStatus(status)
 
 _libpcula.pculaCtrsm.restype = int
@@ -220,7 +220,7 @@ def pculaCtrsm(config, side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb):
     """
 
     status = _libpcula.pculaCtrsm(ctypes.byref(config), side, uplo, transa,
-                                  diag, m, n, alpha, int(a), lda, int(b), ldb)                                  
+                                  diag, m, n, alpha, int(a), lda, int(b), ldb)
     culaCheckStatus(status)
 
 _libpcula.pculaZtrsm.restype = int
@@ -243,7 +243,7 @@ def pculaZtrsm(config, side, uplo, transa, diag, m, n, alpha, a, lda, b, ldb):
     """
 
     status = _libpcula.pculaZtrsm(ctypes.byref(config), side, uplo, transa,
-                                  diag, m, n, alpha, int(a), lda, int(b), ldb)                                  
+                                  diag, m, n, alpha, int(a), lda, int(b), ldb)
     culaCheckStatus(status)
 
 # SGESV, DGESV, CGESV, ZGESV

--- a/skcuda/rlinalg.py
+++ b/skcuda/rlinalg.py
@@ -54,41 +54,41 @@ from . import install_headers
 def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
     """
     Randomized Singular Value Decomposition.
-    
-    Randomized algorithm for computing the approximate low-rank singular value 
-    decomposition of a rectangular (m, n) matrix `a` with target rank `k << n`. 
-    The input matrix a is factored as `a = U * diag(s) * Vt`. The right singluar 
-    vectors are the columns of the real or complex unitary matrix `U`. The left 
-    singular vectors are the columns of the real or complex unitary matrix `V`. 
+
+    Randomized algorithm for computing the approximate low-rank singular value
+    decomposition of a rectangular (m, n) matrix `a` with target rank `k << n`.
+    The input matrix a is factored as `a = U * diag(s) * Vt`. The right singluar
+    vectors are the columns of the real or complex unitary matrix `U`. The left
+    singular vectors are the columns of the real or complex unitary matrix `V`.
     The singular values `s` are non-negative and real numbers.
 
-    The paramter `p` is a oversampling parameter to improve the approximation. 
+    The paramter `p` is a oversampling parameter to improve the approximation.
     A value between 2 and 10 is recommended.
-    
+
     The paramter `q` specifies the number of normlized power iterations
-    (subspace iterations) to reduce the approximation error. This is recommended 
-    if the the singular values decay slowly and in practice 1 or 2 iterations 
+    (subspace iterations) to reduce the approximation error. This is recommended
+    if the the singular values decay slowly and in practice 1 or 2 iterations
     achive good results. However, computing power iterations is increasing the
-    computational time. 
-    
-    If k > (n/1.5), partial SVD or trancated SVD might be faster. 
-    
+    computational time.
+
+    If k > (n/1.5), partial SVD or trancated SVD might be faster.
+
     Parameters
     ----------
     a_gpu : pycuda.gpuarray.GPUArray
         Real/complex input matrix  `a` with dimensions `(m, n)`.
     k : int
-        `k` is the target rank of the low-rank decomposition, k << min(m,n). 
+        `k` is the target rank of the low-rank decomposition, k << min(m,n).
     p : int
         `p` sets the oversampling parameter (default k=0).
     q : int
         `q` sets the number of power iterations (default=0).
     method : `{'standard', 'fast'}`
         'standard' : Standard algorithm as described in [1, 2]
-        'fast' : Version II algorithm as described in [2]   
+        'fast' : Version II algorithm as described in [2]
     handle : int
         CUBLAS context. If no context is specified, the default handle from
-        `skcuda.misc._global_cublas_handle` is used.                
+        `skcuda.misc._global_cublas_handle` is used.
 
     Returns
     -------
@@ -105,9 +105,9 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
     CULA Dense toolkit is installed.
 
     This function destroys the contents of the input matrix.
-    
+
     Arrays are assumed to be stored in column-major order, i.e., order='F'.
-    
+
     Input matrix of shape `(m, n)`, where `n>m` is not supported yet.
 
     References
@@ -117,10 +117,10 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
     algorithms for constructing approximate matrix
     decompositions" (2009).
     (available at `arXiv <http://arxiv.org/abs/0909.4061>`_).
-    
-    S. Voronin and P.Martinsson. 
-    "RSVDPACK: Subroutines for computing partial singular value 
-    decompositions via randomized sampling on single core, multi core, 
+
+    S. Voronin and P.Martinsson.
+    "RSVDPACK: Subroutines for computing partial singular value
+    decompositions via randomized sampling on single core, multi core,
     and GPU architectures" (2015).
     (available at `arXiv <http://arxiv.org/abs/1502.05366>`_).
 
@@ -136,18 +136,18 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
     >>> #Randomized SVD decomposition of the square matrix `a` with single precision.
     >>> #Note: There is no gain to use rsvd if k > int(n/1.5)
     >>> a = np.array(np.random.randn(5, 5), np.float32, order='F')
-    >>> a_gpu = gpuarray.to_gpu(a)  
+    >>> a_gpu = gpuarray.to_gpu(a)
     >>> U, s, Vt = rlinalg.rsvd(a_gpu, k=5, method='standard')
     >>> np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), 1e-4)
     True
 
     >>> #Low-rank SVD decomposition with target rank k=2
     >>> a = np.array(np.random.randn(5, 5), np.float32, order='F')
-    >>> a_gpu = gpuarray.to_gpu(a)  
+    >>> a_gpu = gpuarray.to_gpu(a)
     >>> U, s, Vt = rlinalg.rsvd(a_gpu, k=2, method='standard')
-    
+
     """
-    
+
     #*************************************************************************
     #***        Author: N. Benjamin Erichson <nbe@st-andrews.ac.uk>        ***
     #***                         <September, 2015>                         ***
@@ -208,9 +208,9 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
 
     #CUDA assumes that arrays are stored in column-major order
     m, n = np.array(a_gpu.shape, int)
-    if n>m : raise ValueError('input matrix of shape (m,n), where n>m is not supported')    
-    
-    #Set k 
+    if n>m : raise ValueError('input matrix of shape (m,n), where n>m is not supported')
+
+    #Set k
     if k == None : raise ValueError('k must be provided')
     if k > n or k < 1: raise ValueError('k must be 0 < k <= n')
     kt = k
@@ -220,30 +220,30 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Generate a random sampling matrix O
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if isreal==False: 
+    if isreal==False:
         Oimag_gpu = gpuarray.empty((n,k), real_type, order="F", allocator=alloc)
-        Oreal_gpu = gpuarray.empty((n,k), real_type, order="F", allocator=alloc) 
-        O_gpu = gpuarray.empty((n,k), data_type, order="F", allocator=alloc) 
+        Oreal_gpu = gpuarray.empty((n,k), real_type, order="F", allocator=alloc)
+        O_gpu = gpuarray.empty((n,k), data_type, order="F", allocator=alloc)
         rand.fill_uniform(Oimag_gpu)
         rand.fill_uniform(Oreal_gpu)
         O_gpu = Oreal_gpu + 1j * Oimag_gpu
-        O_gpu = O_gpu.T * 2 - 1 #Scale to [-1,1] 
+        O_gpu = O_gpu.T * 2 - 1 #Scale to [-1,1]
     else:
-        O_gpu = gpuarray.empty((n,k), real_type, order="F", allocator=alloc) 
+        O_gpu = gpuarray.empty((n,k), real_type, order="F", allocator=alloc)
         rand.fill_uniform(O_gpu) #Draw random samples from a ~ Uniform(-1,1) distribution
-        O_gpu = O_gpu * 2 - 1 #Scale to [-1,1]  
-    
-               
-       
+        O_gpu = O_gpu * 2 - 1 #Scale to [-1,1]
+
+
+
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Build sample matrix Y : Y = A * O
     #Note: Y should approximate the range of A
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
-    #Allocate Y    
-    Y_gpu = gpuarray.zeros((m,k), data_type, order="F", allocator=alloc)    
-    #Dot product Y = A * O    
-    cublas_func_gemm(handle, 'n', 'n', m, k, n, alpha, 
-                         a_gpu.gpudata, m, O_gpu.gpudata, n, 
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #Allocate Y
+    Y_gpu = gpuarray.zeros((m,k), data_type, order="F", allocator=alloc)
+    #Dot product Y = A * O
+    cublas_func_gemm(handle, 'n', 'n', m, k, n, alpha,
+                         a_gpu.gpudata, m, O_gpu.gpudata, n,
                          beta, Y_gpu.gpudata, m  )
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -251,7 +251,7 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
     #If q > 0 perfrom q subspace iterations
     #Note: economic QR just returns Q, and destroys Y_gpu
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if q > 0:
         Z_gpu = gpuarray.empty((n,k), data_type, order="F", allocator=alloc)
 
@@ -271,15 +271,15 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
                          beta, Y_gpu.gpudata, m  )
 
         #End for
-     #End if   
+     #End if
 
     Q_gpu = linalg.qr(Y_gpu, 'economic', lib='cula')
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Project the data matrix a into a lower dimensional subspace
-    #B = Q.T * A 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
-    #Allocate B    
+    #B = Q.T * A
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #Allocate B
     B_gpu = gpuarray.empty((k,n), data_type, order="F", allocator=alloc)
     cublas_func_gemm(handle, TRANS_type, 'n', k, n, m, alpha,
                          Q_gpu.gpudata, m, a_gpu.gpudata, m,
@@ -289,7 +289,7 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
         #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #Singular Value Decomposition
         #Note: B = U" * S * Vt
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #gesvd(jobu, jobvt, m, n, int(a), lda, int(s), int(u), ldu, int(vt), ldvt)
         #Allocate s, U, Vt for economic SVD
         #Note: singular values are always real
@@ -302,10 +302,10 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
                         int(U_gpu.gpudata), k, int(Vt_gpu.gpudata), k)
 
         #Compute right singular vectors as U = Q * U"
-        cublas_func_gemm(handle, 'n', 'n', m, k, k, alpha, 
-                         Q_gpu.gpudata, m, U_gpu.gpudata, k, 
+        cublas_func_gemm(handle, 'n', 'n', m, k, k, alpha,
+                         Q_gpu.gpudata, m, U_gpu.gpudata, k,
                          beta, Q_gpu.gpudata, m  )
-        U_gpu =  Q_gpu   #Set pointer            
+        U_gpu =  Q_gpu   #Set pointer
 
         # Free internal CULA memory:
         cula.culaFreeBuffers()
@@ -317,7 +317,7 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
         #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #Orthogonalize B.T using reduced QR decomposition: B.T = Q" * R"
         #Note: reduced QR returns Q and R, and destroys B_gpu
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         if isreal==True:
             B_gpu = transpose(B_gpu) #transpose B
         else:
@@ -328,7 +328,7 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
         #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #Singular Value Decomposition of R"
         #Note: R" = U" * S" * Vt"
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #gesvd(jobu, jobvt, m, n, int(a), lda, int(s), int(u), ldu, int(vt), ldvt)
         #Allocate s, U, Vt for economic SVD
         #Note: singular values are always real
@@ -345,9 +345,9 @@ def rsvd(a_gpu, k=None, p=0, q=0, method="standard", handle=None):
         cublas_func_gemm(handle, 'n', TRANS_type, m, k, k, alpha,
                          Q_gpu.gpudata, m, Vtstar_gpu.gpudata, k,
                          beta, Q_gpu.gpudata, m  )
-        U_gpu =  Q_gpu   #Set pointer  
+        U_gpu =  Q_gpu   #Set pointer
 
-        #Compute left singular vectors as Vt = U".T * Q".T  
+        #Compute left singular vectors as Vt = U".T * Q".T
         Vt_gpu = gpuarray.empty((k,n), data_type, order="F", allocator=alloc)
 
         cublas_func_gemm(handle, TRANS_type, TRANS_type, k, n, k, alpha,
@@ -387,14 +387,14 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     modes : `{'standard', 'exact'}`
         'standard' : uses the standard definition to compute the dynamic modes,
                     `F = U * W`.
-        'exact' : computes the exact dynamic modes, `F = Y * V * (S**-1) * W`.    
+        'exact' : computes the exact dynamic modes, `F = Y * V * (S**-1) * W`.
     method_rsvd : `{'standard', 'fast'}`
-        'standard' : (default) Standard algorithm as described in [1, 2] 
+        'standard' : (default) Standard algorithm as described in [1, 2]
         'fast' : Version II algorithm as described in [2]
-    return_amplitudes : bool `{True, False}` 
-        True: return amplitudes in addition to dynamic modes. 
+    return_amplitudes : bool `{True, False}`
+        True: return amplitudes in addition to dynamic modes.
     return_vandermonde : bool `{True, False}`
-        True: return Vandermonde matrix in addition to dynamic modes and amplitudes.    
+        True: return Vandermonde matrix in addition to dynamic modes and amplitudes.
     handle : int
         CUBLAS context. If no context is specified, the default handle from
         `skcuda.misc._global_cublas_handle` is used.
@@ -447,10 +447,10 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     >>> from skcuda import linalg, rlinalg
     >>> linalg.init()
     >>> rlinalg.init()
-    
+
     >>> # Define time and space discretizations
     >>> x=np.linspace( -15, 15, 200)
-    >>> t=np.linspace(0, 8*np.pi , 80) 
+    >>> t=np.linspace(0, 8*np.pi , 80)
     >>> dt=t[2]-t[1]
     >>> X, T = np.meshgrid(x,t)
     >>> # Create two patio-temporal patterns
@@ -458,7 +458,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     >>> F2 = ( (1./np.cosh(X)) * np.tanh(X)) *(2.*np.exp(1j*2.8*T))
     >>> # Add both signals
     >>> F = (F1+F2)
-    
+
     >>> #Plot dataset
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(231, projection='3d')
@@ -476,10 +476,10 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     >>> surf = ax.plot_surface(X, T, F2, rstride=1, cstride=1, cmap=cm.coolwarm, linewidth=0, antialiased=False)
     >>> ax.set_zlim(-1, 1)
     >>> plt.title('F2')
-    
+
     >>> #Dynamic Mode Decomposition
     >>> F_gpu = np.array(F.T, np.complex64, order='F')
-    >>> F_gpu = gpuarray.to_gpu(F_gpu) 
+    >>> F_gpu = gpuarray.to_gpu(F_gpu)
     >>> Fmodes_gpu, b_gpu, V_gpu, omega_gpu = rlinalg.rdmd(F_gpu, k=2, p=0, q=1, modes='exact', return_amplitudes=True, return_vandermonde=True)
     >>> omega = omega_gpu.get()
     >>> plt.scatter(omega.real, omega.imag, marker='o', c='r')
@@ -487,7 +487,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     >>> #Recover original signal
     >>> F1tilde = np.dot(Fmodes_gpu[:,0:1].get() , np.dot(b_gpu[0].get(), V_gpu[0:1,:].get() ) )
     >>> F2tilde = np.dot(Fmodes_gpu[:,1:2].get() , np.dot(b_gpu[1].get(), V_gpu[1:2,:].get() ) )
-    
+
     >>> #Plot DMD modes
     >>> #Mode 0
     >>> ax = fig.add_subplot(235, projection='3d')
@@ -501,7 +501,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     >>> surf = ax.plot_surface(X[0:F2tilde.shape[1],:], T[0:F2tilde.shape[1],:], F2tilde.T, rstride=1, cstride=1, cmap=cm.coolwarm, linewidth=0, antialiased=False)
     >>> ax.set_zlim(-1, 1)
     >>> plt.title('F2_tilde')
-    >>> plt.show()     
+    >>> plt.show()
     """
 
     #*************************************************************************
@@ -577,7 +577,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     #CUDA assumes that arrays are stored in column-major order
     m, n = np.array(a_gpu.shape, int)
     nx = n-1
-    #Set k     
+    #Set k
     if k == None : k = nx
     if k > nx or k < 1: raise ValueError('k is not valid')
 
@@ -586,26 +586,26 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Note: we need a copy of X_gpu, because SVD destroys X_gpu
     #While Y_gpu is just a pointer
-    X_gpu = gpuarray.empty((m, n), data_type, order="F", allocator=alloc) 
+    X_gpu = gpuarray.empty((m, n), data_type, order="F", allocator=alloc)
     copy_func(handle, X_gpu.size, int(a_gpu.gpudata), 1, int(X_gpu.gpudata), 1)
-    X_gpu = X_gpu[:, :nx]    
-    Y_gpu = a_gpu[:, 1:] 
+    X_gpu = X_gpu[:, :nx]
+    Y_gpu = a_gpu[:, 1:]
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Randomized Singular Value Decomposition
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
-    U_gpu, s_gpu, Vh_gpu = rsvd(X_gpu, k=k, p=p, q=q, 
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    U_gpu, s_gpu, Vh_gpu = rsvd(X_gpu, k=k, p=p, q=q,
                                 method=method_rsvd, handle=handle)
 
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    #Solve the LS problem to find estimate for M using the pseudo-inverse    
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+    #Solve the LS problem to find estimate for M using the pseudo-inverse
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #real: M = U.T * Y * Vt.T * S**-1
     #complex: M = U.H * Y * Vt.H * S**-1
     #Let G = Y * Vt.H * S**-1, hence M = M * G
 
-    #Allocate G and M  
+    #Allocate G and M
     G_gpu = gpuarray.empty((m,k), data_type, order="F", allocator=alloc)
     M_gpu = gpuarray.empty((k,k), data_type, order="F", allocator=alloc)
 
@@ -616,7 +616,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     else:
         s_gpu = 1.0/s_gpu
 
-    #ii) real/complex: scale Vs =  Vt* x diag(s**-1) 
+    #ii) real/complex: scale Vs =  Vt* x diag(s**-1)
     Vs_gpu = gpuarray.empty((nx,k), data_type, order="F", allocator=alloc)
     lda = max(1, Vh_gpu.strides[1] // Vh_gpu.dtype.itemsize)
     ldb = max(1, Vs_gpu.strides[1] // Vs_gpu.dtype.itemsize)
@@ -632,7 +632,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
                      int(Y_gpu.gpudata), m, int(Vs_gpu.gpudata), nx,
                         beta, int(G_gpu.gpudata), m )
 
-    #iv) real/complex: M = U* x G 
+    #iv) real/complex: M = U* x G
     cublas_func_gemm(handle, TRANS_type, 'n', k, k, m, alpha,
                      int(U_gpu.gpudata), m, int(G_gpu.gpudata), m,
                     beta, int(M_gpu.gpudata), k )
@@ -644,9 +644,9 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     Vr_gpu, w_gpu = linalg.eig(M_gpu, 'N', 'V', 'F', lib='cula')
     omega = cumath.log(w_gpu)
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-    #Compute DMD Modes 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #Compute DMD Modes
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     F_gpu = gpuarray.empty((m,k), data_type, order="F", allocator=alloc)
     modes = modes.lower()
     if modes == 'exact': #Compute (exact) DMD modes: F = Y * V * S**-1 * W = G * W
@@ -663,7 +663,7 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     else:
         raise ValueError('Type of modes is not supported, choose "exact" or "standard".')
 
-    #Copy is required, because gels destroys input    
+    #Copy is required, because gels destroys input
     copy_func(handle, F_gpu_temp.size, int(F_gpu_temp.gpudata),
               1, int(F_gpu.gpudata), 1)
 
@@ -671,24 +671,24 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     #Compute amplitueds b using least-squares: Fb=x1
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if return_amplitudes==True:
-        #x1_gpu = a_gpu[:,0].copy() 
+        #x1_gpu = a_gpu[:,0].copy()
         x1_gpu = gpuarray.empty(m, data_type, order="F", allocator=alloc)
         copy_func(handle, x1_gpu.size, int(a_gpu[:,0].gpudata), 1, int(x1_gpu.gpudata), 1)
         cula_func_gels( 'N', m, k, int(1) , F_gpu_temp.gpudata, m, x1_gpu.gpudata, m)
         b_gpu = x1_gpu
-    
+
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Compute Vandermonde matrix (CPU)
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if return_vandermonde==True:      
+    if return_vandermonde==True:
         V_gpu = linalg.vander(w_gpu, n=nx)
-    
+
     # Free internal CULA memory:
     cula.culaFreeBuffers()
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    #Return 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+    #Return
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if return_amplitudes==True and return_vandermonde==True:
         return F_gpu, b_gpu[:k], V_gpu, omega
     elif return_amplitudes==True and return_vandermonde==False:
@@ -696,8 +696,8 @@ def rdmd(a_gpu, k=None, p=5, q=1, modes='exact', method_rsvd='standard', return_
     elif return_amplitudes==False and return_vandermonde==True:
         return F_gpu, V_gpu, omega
     else:
-        return F_gpu, omega   
-  
+        return F_gpu, omega
+
 
 
 def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_vandermonde=False, handle=None):
@@ -721,10 +721,10 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
         `p` sets the number of measurements sensors.
     modes : `{'exact'}`
         'exact' : computes the exact dynamic modes, `F = Y * V * (S**-1) * W`.
-    return_amplitudes : bool `{True, False}` 
-        True: return amplitudes in addition to dynamic modes. 
+    return_amplitudes : bool `{True, False}`
+        True: return amplitudes in addition to dynamic modes.
     return_vandermonde : bool `{True, False}`
-        True: return Vandermonde matrix in addition to dynamic modes and amplitudes.          
+        True: return Vandermonde matrix in addition to dynamic modes and amplitudes.
     handle : int
         CUBLAS context. If no context is specified, the default handle from
         `skcuda.misc._global_cublas_handle` is used.
@@ -750,13 +750,13 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     References
     ----------
     S. L. Brunton, et al.
-    "Compressed sampling and dynamic mode decomposition."  
+    "Compressed sampling and dynamic mode decomposition."
     arXiv preprint arXiv:1312.5186 (2013).
-    
+
     J. H. Tu, et al.
     "On dynamic mode decomposition: theory and applications."
     arXiv preprint arXiv:1312.0041 (2013).
-    
+
     Examples
     --------
     >>> #Numpy
@@ -771,10 +771,10 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     >>> from skcuda import linalg, rlinalg
     >>> linalg.init()
     >>> rlinalg.init()
-    
+
     >>> # Define time and space discretizations
     >>> x=np.linspace( -15, 15, 200)
-    >>> t=np.linspace(0, 8*np.pi , 80) 
+    >>> t=np.linspace(0, 8*np.pi , 80)
     >>> dt=t[2]-t[1]
     >>> X, T = np.meshgrid(x,t)
     >>> # Create two patio-temporal patterns
@@ -782,7 +782,7 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     >>> F2 = ( (1./np.cosh(X)) * np.tanh(X)) *(2.*np.exp(1j*2.8*T))
     >>> # Add both signals
     >>> F = (F1+F2)
-    
+
     >>> #Plot dataset
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(231, projection='3d')
@@ -800,19 +800,19 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     >>> surf = ax.plot_surface(X, T, F2, rstride=1, cstride=1, cmap=cm.coolwarm, linewidth=0, antialiased=False)
     >>> ax.set_zlim(-1, 1)
     >>> plt.title('F2')
-    
-    
+
+
     >>> #Dynamic Mode Decomposition
     >>> F_gpu = np.array(F.T, np.complex64, order='F')
-    >>> F_gpu = gpuarray.to_gpu(F_gpu) 
+    >>> F_gpu = gpuarray.to_gpu(F_gpu)
     >>> Fmodes_gpu, b_gpu, V_gpu, omega_gpu = rlinalg.cdmd(F_gpu, k=2, c=20, modes='exact', return_amplitudes=True, return_vandermonde=True)
     >>> omega = omega_gpu.get()
     >>> plt.scatter(omega.real, omega.imag, marker='o', c='r')
-    
+
     >>> #Recover original signal
     >>> F1tilde = np.dot(Fmodes_gpu[:,0:1].get() , np.dot(b_gpu[0].get(), V_gpu[0:1,:].get() ) )
     >>> F2tilde = np.dot(Fmodes_gpu[:,1:2].get() , np.dot(b_gpu[1].get(), V_gpu[1:2,:].get() ) )
-    
+
     >>> # Plot DMD modes
     >>> #Mode 0
     >>> ax = fig.add_subplot(235, projection='3d')
@@ -826,7 +826,7 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     >>> surf = ax.plot_surface(X[0:F2tilde.shape[1],:], T[0:F2tilde.shape[1],:], F2tilde.T, rstride=1, cstride=1, cmap=cm.coolwarm, linewidth=0, antialiased=False)
     >>> ax.set_zlim(-1, 1)
     >>> plt.title('F2_tilde')
-    >>> plt.show()     
+    >>> plt.show()
     """
 
     #*************************************************************************
@@ -902,7 +902,7 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     #CUDA assumes that arrays are stored in column-major order
     m, n = np.array(a_gpu.shape, int)
     nx = n-1
-    #Set k     
+    #Set k
     if k == None : k = nx
     if k > nx or k < 1: raise ValueError('k is not valid')
 
@@ -916,101 +916,101 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
         #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #Generate a random sensing matrix S
         #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if isreal==False: 
+        if isreal==False:
             Simag_gpu = gpuarray.empty((m,c), real_type, order="F", allocator=alloc)
-            Sreal_gpu = gpuarray.empty((m,c), real_type, order="F", allocator=alloc) 
-            S_gpu = gpuarray.empty((c,m), data_type, order="F", allocator=alloc) 
+            Sreal_gpu = gpuarray.empty((m,c), real_type, order="F", allocator=alloc)
+            S_gpu = gpuarray.empty((c,m), data_type, order="F", allocator=alloc)
             rand.fill_uniform(Simag_gpu)
             rand.fill_uniform(Sreal_gpu)
             S_gpu = Sreal_gpu + 1j * Simag_gpu
-            S_gpu = S_gpu.T * 2 -1 #Scale to [-1,1] 
+            S_gpu = S_gpu.T * 2 -1 #Scale to [-1,1]
         else:
-            S_gpu = gpuarray.empty((c,m), real_type, order="F", allocator=alloc) 
+            S_gpu = gpuarray.empty((c,m), real_type, order="F", allocator=alloc)
             rand.fill_uniform(S_gpu) #Draw random samples from a ~ Uniform(-1,1) distribution
-            S_gpu = S_gpu * 2 - 1 #Scale to [-1,1]  
-        
-            
-        #Allocate Ac 
-        Ac_gpu = gpuarray.empty((c,n), data_type, order="F", allocator=alloc)   
+            S_gpu = S_gpu * 2 - 1 #Scale to [-1,1]
+
+
+        #Allocate Ac
+        Ac_gpu = gpuarray.empty((c,n), data_type, order="F", allocator=alloc)
 
         #Compress input matrix
-        cublas_func_gemm(handle, 'n', 'n', c, n, m, alpha, 
-                     int(S_gpu.gpudata), c, int(a_gpu.gpudata), m, 
-                        beta, int(Ac_gpu.gpudata), c )         
-                        
+        cublas_func_gemm(handle, 'n', 'n', c, n, m, alpha,
+                     int(S_gpu.gpudata), c, int(a_gpu.gpudata), m,
+                        beta, int(Ac_gpu.gpudata), c )
+
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Split data into lef and right snapshot sequence
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Note: we need a copy of X_gpu, because SVD destroys X_gpu
     #While Y_gpu is just a pointer
-    X_gpu = gpuarray.empty((c, n), data_type, order="F", allocator=alloc) 
+    X_gpu = gpuarray.empty((c, n), data_type, order="F", allocator=alloc)
     copy_func(handle, X_gpu.size, int(Ac_gpu.gpudata), 1, int(X_gpu.gpudata), 1)
-    X_gpu = X_gpu[:, :nx]    
-    Y_gpu = Ac_gpu[:, 1:] 
-    Yorig_gpu = a_gpu[:, 1:]     
-    
+    X_gpu = X_gpu[:, :nx]
+    Y_gpu = Ac_gpu[:, 1:]
+    Yorig_gpu = a_gpu[:, 1:]
+
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Singular Value Decomposition
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Allocate s, U, Vt for economic SVD
     #Note: singular values are always real
     min_s = min(nx,c)
     s_gpu = gpuarray.zeros(min_s, real_type, order="F", allocator=alloc)
     U_gpu = gpuarray.zeros((c,min_s), data_type, order="F", allocator=alloc)
     Vh_gpu = gpuarray.zeros((min_s,nx), data_type, order="F", allocator=alloc)
-    
+
    #Economic SVD
-    cula_func_gesvd('S', 'S', c, nx, int(X_gpu.gpudata), c, int(s_gpu.gpudata), 
+    cula_func_gesvd('S', 'S', c, nx, int(X_gpu.gpudata), c, int(s_gpu.gpudata),
                     int(U_gpu.gpudata), c, int(Vh_gpu.gpudata), min_s)
-     
+
     #Low-rank DMD: trancate SVD if k < nx
     if k != nx:
         s_gpu = s_gpu[:k]
         U_gpu = U_gpu[: , :k]
         Vh_gpu = Vh_gpu[:k , : ]
-    
+
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    #Solve the LS problem to find estimate for M using the pseudo-inverse    
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+    #Solve the LS problem to find estimate for M using the pseudo-inverse
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #real: M = U.T * Y * Vt.T * S**-1
     #complex: M = U.H * Y * Vt.H * S**-1
     #Let G = Y * Vt.H * S**-1, hence M = M * G
-    
-    #Allocate G and M  
-    G_gpu = gpuarray.zeros((c,k), data_type, order="F", allocator=alloc)    
-    M_gpu = gpuarray.zeros((k,k), data_type, order="F", allocator=alloc)    
-    
+
+    #Allocate G and M
+    G_gpu = gpuarray.zeros((c,k), data_type, order="F", allocator=alloc)
+    M_gpu = gpuarray.zeros((k,k), data_type, order="F", allocator=alloc)
+
     #i) s = s **-1 (inverse)
     if data_type == np.complex64 or data_type == np.complex128:
         s_gpu = 1/s_gpu
         s_gpu = s_gpu + 1j * gpuarray.zeros_like(s_gpu)
     else:
         s_gpu = 1/s_gpu
-    
-    
-    #ii) real/complex: scale Vs =  Vt* x diag(s**-1) 
-    Vs_gpu = gpuarray.zeros((nx,k), data_type, order="F", allocator=alloc)      
+
+
+    #ii) real/complex: scale Vs =  Vt* x diag(s**-1)
+    Vs_gpu = gpuarray.zeros((nx,k), data_type, order="F", allocator=alloc)
     lda = max(1, Vh_gpu.strides[1] // Vh_gpu.dtype.itemsize)
     ldb = max(1, Vs_gpu.strides[1] // Vs_gpu.dtype.itemsize)
     transpose_func(handle, TRANS_type, TRANS_type, nx, k,
                    1.0, int(Vh_gpu.gpudata), lda, 0.0, int(Vh_gpu.gpudata), lda,
-                   int(Vs_gpu.gpudata), ldb)       
+                   int(Vs_gpu.gpudata), ldb)
     #End Transpose
-    
-    cublas_func_dgmm(handle, 'r', nx, k, int(Vs_gpu.gpudata), nx, 
+
+    cublas_func_dgmm(handle, 'r', nx, k, int(Vs_gpu.gpudata), nx,
                      int(s_gpu.gpudata), 1 , int(Vs_gpu.gpudata), nx)
-   
+
 
     #iii) real: G = Y * Vs , complex: G = Y x Vs
-    cublas_func_gemm(handle, 'n', 'n', c, k, nx, alpha, 
-                     int(Y_gpu.gpudata), c, int(Vs_gpu.gpudata), nx, 
-                        beta, int(G_gpu.gpudata), c )      
-   
-    
-    #iv) real/complex: M = U* x G 
-    cublas_func_gemm(handle, TRANS_type, 'n', k, k, c, alpha, 
-                     int(U_gpu.gpudata), c, int(G_gpu.gpudata), c, 
-                    beta, int(M_gpu.gpudata), k )   
+    cublas_func_gemm(handle, 'n', 'n', c, k, nx, alpha,
+                     int(Y_gpu.gpudata), c, int(Vs_gpu.gpudata), nx,
+                        beta, int(G_gpu.gpudata), c )
+
+
+    #iv) real/complex: M = U* x G
+    cublas_func_gemm(handle, TRANS_type, 'n', k, k, c, alpha,
+                     int(U_gpu.gpudata), c, int(G_gpu.gpudata), c,
+                    beta, int(M_gpu.gpudata), k )
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Eigen Decomposition
@@ -1020,9 +1020,9 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
 
     omega = cumath.log(w_gpu)
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-    #Compute DMD Modes 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #Compute DMD Modes
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     F_gpu = gpuarray.empty((m,k), data_type, order="F", allocator=alloc)
     modes = modes.lower()
     if modes == 'exact': #Compute (exact) DMD modes: F = Y * V * S**-1 * W = G * W
@@ -1035,39 +1035,39 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
                          Yorig_gpu.gpudata, m, Vs_gpu.gpudata, nx,
                          beta, F_gpu.gpudata, m  )
 
-    else: 
+    else:
         raise ValueError('Type of modes is not supported, choose "exact" or "standard".')
-    
+
 
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Compute amplitueds b using least-squares: Fb=x1
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if return_amplitudes==True:  
-        F_gpu_temp = gpuarray.empty((m,k), data_type, order="F", allocator=alloc)        
-        
-        #Copy is required, because gels destroys input    
-        copy_func(handle, F_gpu.size, int(F_gpu.gpudata), 
+    if return_amplitudes==True:
+        F_gpu_temp = gpuarray.empty((m,k), data_type, order="F", allocator=alloc)
+
+        #Copy is required, because gels destroys input
+        copy_func(handle, F_gpu.size, int(F_gpu.gpudata),
               1, int(F_gpu_temp.gpudata), 1)
-        
-        #x1_gpu = a_gpu[:,0].copy() 
-        x1_gpu = gpuarray.empty(m, data_type, order="F", allocator=alloc) 
+
+        #x1_gpu = a_gpu[:,0].copy()
+        x1_gpu = gpuarray.empty(m, data_type, order="F", allocator=alloc)
         copy_func(handle, x1_gpu.size, int(a_gpu[:,0].gpudata), 1, int(x1_gpu.gpudata), 1)
         cula_func_gels( 'N', m, k, int(1) , F_gpu_temp.gpudata, m, x1_gpu.gpudata, m)
         b_gpu = x1_gpu
-    
+
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     #Compute Vandermonde matrix (CPU)
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if return_vandermonde==True:      
+    if return_vandermonde==True:
         V_gpu = linalg.vander(w_gpu, n=nx)
-    
+
     # Free internal CULA memory:
     cula.culaFreeBuffers()
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    #Return 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+    #Return
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if return_amplitudes==True and return_vandermonde==True:
         return F_gpu, b_gpu[:k], V_gpu, omega
     elif return_amplitudes==True and return_vandermonde==False:
@@ -1075,9 +1075,9 @@ def cdmd(a_gpu, k=None, c=None,  modes='exact', return_amplitudes=False, return_
     elif return_amplitudes==False and return_vandermonde==True:
         return F_gpu, V_gpu, omega
     else:
-        return F_gpu, omega   
+        return F_gpu, omega
 
-        
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/tests/test_cublasxt.py
+++ b/tests/test_cublasxt.py
@@ -41,7 +41,7 @@ class test_cublasxt(TestCase):
         b = np.random.rand(4, 4).astype(np.float32)
         c = np.zeros((4, 4), np.float32)
         cublasxt.cublasXtSgemm(self.handle,
-                               'N', 'N', 
+                               'N', 'N',
                                4, 4, 4, np.float32(1.0),
                                a.ctypes.data, 4, b.ctypes.data, 4, np.float32(0.0),
                                c.ctypes.data, 4)
@@ -51,11 +51,11 @@ class test_cublasxt(TestCase):
         a = np.random.rand(4, 4).astype(np.float64)
         b = np.random.rand(4, 4).astype(np.float64)
         c = np.zeros((4, 4), np.float64)
-        
+
         cublasxt.cublasXtDgemm(self.handle,
                                'N', 'N', 4, 4, 4,
                                np.float64(1.0),
-                               a.ctypes.data, 4, b.ctypes.data, 4, np.float64(0.0),                               
+                               a.ctypes.data, 4, b.ctypes.data, 4, np.float64(0.0),
                                c.ctypes.data, 4)
         np.allclose(np.dot(b.T, a.T).T, c)
 
@@ -63,9 +63,9 @@ class test_cublasxt(TestCase):
         a = (np.random.rand(4, 4)+1j*np.random.rand(4, 4)).astype(np.complex128)
         b = (np.random.rand(4, 4)+1j*np.random.rand(4, 4)).astype(np.complex128)
         c = np.zeros((4, 4), np.complex128)
-        
+
         cublasxt.cublasXtCgemm(self.handle,
-                               'N', 'N', 4, 4, 4,           
+                               'N', 'N', 4, 4, 4,
                                np.complex128(1.0),
                                a.ctypes.data, 4, b.ctypes.data, 4, np.complex128(0.0),
                                c.ctypes.data, 4)
@@ -75,7 +75,7 @@ class test_cublasxt(TestCase):
         a = (np.random.rand(4, 4)+1j*np.random.rand(4, 4)).astype(np.complex256)
         b = (np.random.rand(4, 4)+1j*np.random.rand(4, 4)).astype(np.complex256)
         c = np.zeros((4, 4), np.complex256)
-        
+
         cublasxt.cublasXtZgemm(self.handle,
                                'N', 'N', 4, 4, 4,
                                np.complex256(1.0),

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -32,7 +32,7 @@ class test_linalg(TestCase):
     def setUpClass(cls):
         cls.ctx = make_default_context()
         linalg.init()
- 
+
     @classmethod
     def tearDownClass(cls):
         linalg.shutdown()
@@ -42,7 +42,7 @@ class test_linalg(TestCase):
     def setUp(self):
         np.random.seed(0)
 
-        ### required for PCA tests ##### 
+        ### required for PCA tests #####
         self.M = 1000
         self.N = 100
         self.test_pca = linalg.PCA()
@@ -57,7 +57,7 @@ class test_linalg(TestCase):
         self.Xf = gpuarray.to_gpu(Xf_)
         self.XdT = gpuarray.to_gpu(Xd_.T.copy())
         self.XfT = gpuarray.to_gpu(Xf_.T.copy())
-        
+
     def test_pca_ortho_type_and_shape_float64_all_comp(self):
         # test that the shape is what we think it should be
         Td_all = self.test_pca.fit_transform(self.Xd)
@@ -86,12 +86,12 @@ class test_linalg(TestCase):
         self.assertTrue(linalg.dot(Td_2[:,0].copy(), Td_2[:,1].copy()) < self.max_ddot)
 
     def test_pca_ortho_type_and_shape_float32(self):
-        # test that the shape is what we think it should be	
+        # test that the shape is what we think it should be
         Tf_2 = self.test_pca2.fit_transform(self.Xf)
         self.assertIsNotNone(Tf_2)
         self.assertEqual(Tf_2.dtype, np.float32)
         self.assertEqual(Tf_2.shape, (self.M, self.K))
-        self.assertTrue(linalg.dot(Tf_2[:,0].copy(), Tf_2[:,1].copy()) < self.max_sdot) 
+        self.assertTrue(linalg.dot(Tf_2[:,0].copy(), Tf_2[:,1].copy()) < self.max_sdot)
 
     def test_pca_trans_ortho_type_and_shape_float64_all_comp(self):
         # test that the shape is what we think it should be
@@ -121,12 +121,12 @@ class test_linalg(TestCase):
         self.assertTrue(linalg.dot(Td_2[0,:].copy(), Td_2[1,:].copy()) < self.max_ddot)
 
     def test_pca_trans_ortho_type_and_shape_float32(self):
-        # test that the shape is what we think it should be	
+        # test that the shape is what we think it should be
         Tf_2 = self.test_pca2.fit_transform(self.XfT, True)
         self.assertIsNotNone(Tf_2)
         self.assertEqual(Tf_2.dtype, np.float32)
         self.assertEqual(Tf_2.shape, (self.K, self.M))
-        self.assertTrue(linalg.dot(Tf_2[0,:], Tf_2[1,:]) < self.max_sdot) 
+        self.assertTrue(linalg.dot(Tf_2[0,:], Tf_2[1,:]) < self.max_sdot)
 
     def test_pca_f_contiguous_check(self):
         try:
@@ -140,11 +140,11 @@ class test_linalg(TestCase):
     def test_pca_arr_2d_check(self):
         try:
             X_trash = np.random.rand(self.M, self.M, 3).astype(np.float32)
-            X_gpu_trash = gpuarray.to_gpu(X_trash)	
+            X_gpu_trash = gpuarray.to_gpu(X_trash)
             self.test_pca2.fit_transform(X_gpu_trash)
-            
+
             # should not reach this line. The prev line should fail and go to the except block
-            fail(msg="PCA Array dimensions check failed") 
+            fail(msg="PCA Array dimensions check failed")
         except ValueError:
             pass
 
@@ -152,9 +152,9 @@ class test_linalg(TestCase):
         self.test_pca.set_n_components(self.N+1)
         self.assertEqual(self.test_pca.get_n_components(), self.N+1)
         T1 = self.test_pca.fit_transform(self.Xf)
-        
+
         # should have been reset internally once the algorithm saw K was bigger than N
-        self.assertEqual(T1.shape[1], self.N)  
+        self.assertEqual(T1.shape[1], self.N)
 
     def test_pca_type_error_check(self):
         try:
@@ -163,7 +163,7 @@ class test_linalg(TestCase):
             self.test_pca2.fit_transform(X_gpu_trash)
 
             # should not reach this line. The prev line should fail and go to the except block
-            fail(msg="PCA Array data type check failed")         
+            fail(msg="PCA Array data type check failed")
         except TypeError:
             pass
 
@@ -301,7 +301,7 @@ class test_linalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         b_gpu = gpuarray.to_gpu(b)
         c_gpu = linalg.dot(a_gpu, b_gpu)
-        assert_allclose(np.dot(a, b), c_gpu.get(), 
+        assert_allclose(np.dot(a, b), c_gpu.get(),
                             rtol=dtype_to_rtol[dtype],
                             atol=dtype_to_atol[dtype])
 
@@ -952,7 +952,7 @@ class test_linalg(TestCase):
         a_inv_gpu = linalg.pinv(a_gpu, lib='cusolver')
         assert_allclose(np.linalg.pinv(a), a_inv_gpu.get(),
                             atol=dtype_to_atol[np.complex64],
-                            rtol=dtype_to_rtol[np.complex64])                          
+                            rtol=dtype_to_rtol[np.complex64])
 
     def test_pinv_cusolver_complex128(self):
         a = np.asarray(np.random.rand(4, 8) + \
@@ -977,7 +977,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.tril(a_gpu)
         assert_allclose(np.tril(a), l_gpu.get(),
                             atol=dtype_to_atol[np.float64],
-                            rtol=dtype_to_rtol[np.float64]) 
+                            rtol=dtype_to_rtol[np.float64])
 
     def test_tril_complex64(self):
         a = np.asarray(np.random.rand(4, 4), np.complex64)
@@ -985,7 +985,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.tril(a_gpu)
         assert_allclose(np.tril(a), l_gpu.get(),
                             atol=dtype_to_atol[np.complex64],
-                            rtol=dtype_to_rtol[np.complex64])                          
+                            rtol=dtype_to_rtol[np.complex64])
 
     def test_tril_complex128(self):
         a = np.asarray(np.random.rand(4, 4), np.complex128)
@@ -993,7 +993,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.tril(a_gpu)
         assert_allclose(np.tril(a), l_gpu.get(),
                             atol=dtype_to_atol[np.complex128],
-                            rtol=dtype_to_rtol[np.complex128])                          
+                            rtol=dtype_to_rtol[np.complex128])
 
     def test_triu_float32(self):
         a = np.asarray(np.random.rand(4, 4), np.float32)
@@ -1001,7 +1001,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.triu(a_gpu)
         assert_allclose(np.triu(a), l_gpu.get(),
                             atol=dtype_to_atol[np.float32],
-                            rtol=dtype_to_rtol[np.float32])                          
+                            rtol=dtype_to_rtol[np.float32])
 
     def test_triu_float64(self):
         a = np.asarray(np.random.rand(4, 4), np.float64)
@@ -1009,7 +1009,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.triu(a_gpu)
         assert_allclose(np.triu(a), l_gpu.get(),
                             atol=dtype_to_atol[np.float64],
-                            rtol=dtype_to_rtol[np.float64])                          
+                            rtol=dtype_to_rtol[np.float64])
 
     def test_triu_complex64(self):
         a = np.asarray(np.random.rand(4, 4), np.complex64)
@@ -1017,7 +1017,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.triu(a_gpu)
         assert_allclose(np.triu(a), l_gpu.get(),
                             atol=dtype_to_atol[np.complex64],
-                            rtol=dtype_to_rtol[np.complex64])                          
+                            rtol=dtype_to_rtol[np.complex64])
 
     def test_triu_complex128(self):
         a = np.asarray(np.random.rand(4, 4), np.complex128)
@@ -1025,7 +1025,7 @@ class test_linalg(TestCase):
         l_gpu = linalg.triu(a_gpu)
         assert_allclose(np.triu(a), l_gpu.get(),
                             atol=dtype_to_atol[np.complex128],
-                            rtol=dtype_to_rtol[np.complex128])                          
+                            rtol=dtype_to_rtol[np.complex128])
 
     def _impl_test_multiply(self, N, dtype):
         mk_matrix = lambda N, dtype: np.asarray(np.random.rand(N, N), dtype)

--- a/tests/test_magma.py
+++ b/tests/test_magma.py
@@ -7,8 +7,8 @@ Real symmetric eigensolvers: magma_[s,d]syevd[,x][,_m,_gpu]
 """
 from unittest import (
     main,
-    # makeSuite, 
-    # skipUnless, 
+    # makeSuite,
+    # skipUnless,
     TestCase,
     TestSuite
 )
@@ -67,7 +67,7 @@ class test_magma(TestCase):
         mat = np.random.rand(self.N*self.N)
         if type_key in ['c', 'z']:
             mat = mat + 1j*np.random.rand(self.N*self.N)
-        
+
         mat = mat.astype(dtype).reshape((self.N, self.N), order='F')
         mat_numpy = mat.copy() # cpu
 

--- a/tests/test_rlinalg.py
+++ b/tests/test_rlinalg.py
@@ -35,7 +35,7 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         U, s, Vt = rlinalg.rsvd(a_gpu, k=n, p=0, q=2, method='standard')
         assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float32)
-       
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rsvd_float64(self):
         m, n = 5, 4
@@ -43,7 +43,7 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         U, s, Vt = rlinalg.rsvd(a_gpu, k=n, p=0, q=2, method='standard')
         assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float64)
-    
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rsvd_complex64(self):
         m, n = 5, 4
@@ -51,7 +51,7 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         U, s, Vt = rlinalg.rsvd(a_gpu, k=n, p=0, q=2, method='standard')
         assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float32)
-        
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rsvd_complex128(self):
         m, n = 5, 4
@@ -59,7 +59,7 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         U, s, Vt = rlinalg.rsvd(a_gpu, k=n, p=0, q=2, method='standard')
         assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float64)
-     
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rsvdf_float32(self):
         m, n = 5, 4
@@ -75,7 +75,7 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         U, s, Vt = rlinalg.rsvd(a_gpu, k=n, p=0, q=2, method='fast')
         assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float64)
-    
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rsvdf_complex64(self):
         m, n = 5, 4
@@ -90,15 +90,15 @@ class test_rlinalg(TestCase):
         a = np.array(np.random.randn(m, n) + 1j*np.random.randn(m, n), np.complex128, order='F')
         a_gpu = gpuarray.to_gpu(a)
         U, s, Vt = rlinalg.rsvd(a_gpu, k=n, p=0, q=2, method='fast')
-        assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float64) 
+        assert np.allclose(a, np.dot(U.get(), np.dot(np.diag(s.get()), Vt.get())), atol_float64)
 
-    @skipUnless(linalg._has_cula, 'CULA required')        
+    @skipUnless(linalg._has_cula, 'CULA required')
     def test_rdmd_float32(self):
         m, n = 6, 4
         a = np.array(np.fliplr(np.vander(np.random.rand(m)+1, n)), np.float32, order='F')
         a_gpu = gpuarray.to_gpu(a)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.rdmd(a_gpu, k=(n-1), p=1, q=2, modes='standard', return_amplitudes=True, return_vandermonde=True)
-        assert np.allclose(a[:,:(n-1)], np.dot(f_gpu.get(), np.dot(np.diag(b_gpu.get()), v_gpu.get()) ), atol_float32)   
+        assert np.allclose(a[:,:(n-1)], np.dot(f_gpu.get(), np.dot(np.diag(b_gpu.get()), v_gpu.get()) ), atol_float32)
 
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rdmd_float64(self):
@@ -106,21 +106,21 @@ class test_rlinalg(TestCase):
         a = np.array(np.fliplr(np.vander(np.random.rand(m)+1, n)), np.float64, order='F')
         a_gpu = gpuarray.to_gpu(a)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.rdmd(a_gpu, k=(n-1), p=1, q=2, modes='standard', return_amplitudes=True, return_vandermonde=True)
-        assert np.allclose(a[:,:(n-1)], np.dot(f_gpu.get(), np.dot(np.diag(b_gpu.get()), v_gpu.get()) ), atol_float64)  
+        assert np.allclose(a[:,:(n-1)], np.dot(f_gpu.get(), np.dot(np.diag(b_gpu.get()), v_gpu.get()) ), atol_float64)
 
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rdmd_complex64(self):
         m, n = 9, 7
-        a = np.array(np.fliplr(np.vander(np.random.rand(m)+1, n)) + 1j*np.fliplr(np.vander(np.random.rand(m)+1, n)), 
+        a = np.array(np.fliplr(np.vander(np.random.rand(m)+1, n)) + 1j*np.fliplr(np.vander(np.random.rand(m)+1, n)),
                      np.complex64, order='F')
         a_gpu = gpuarray.to_gpu(a)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.rdmd(a_gpu, k=(n-1), p=1, q=1, modes='standard', return_amplitudes=True, return_vandermonde=True)
         assert np.allclose(a[:,:(n-1)], np.dot(f_gpu.get(), np.dot(np.diag(b_gpu.get()), v_gpu.get()) ), atol_float32)
-        
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_rdmd_complex128(self):
         m, n = 9, 7
-        a = np.array(np.fliplr(np.vander(np.random.rand(m)+1, n)) + 1j*np.fliplr(np.vander(np.random.rand(m)+1, n)), 
+        a = np.array(np.fliplr(np.vander(np.random.rand(m)+1, n)) + 1j*np.fliplr(np.vander(np.random.rand(m)+1, n)),
                      np.complex128, order='F')
         a_gpu = gpuarray.to_gpu(a)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.rdmd(a_gpu, k=(n-1), p=1, q=1, modes='standard', return_amplitudes=True, return_vandermonde=True)
@@ -130,7 +130,7 @@ class test_rlinalg(TestCase):
     def test_cdmd_float32(self):
         # Define time and space discretizations
         x=np.linspace( -5, 5, 50)
-        t=np.linspace(0, 8*np.pi , 20) 
+        t=np.linspace(0, 8*np.pi , 20)
         dt=t[2]-t[1]
         X, T = np.meshgrid(x,t)
         # Create two spatio-temporal patterns
@@ -141,13 +141,13 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         dmdf_gpu, dmdb_gpu, dmdv_gpu, dmdomega = linalg.dmd(a_gpu, k=2, modes='exact', return_amplitudes=True, return_vandermonde=True)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.cdmd(a_gpu, k=2, c=10, modes='exact', return_amplitudes=True, return_vandermonde=True)
-        assert np.allclose(dmdomega.get(), omega.get(), atol_float32)   
+        assert np.allclose(dmdomega.get(), omega.get(), atol_float32)
 
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_cdmd_float64(self):
         # Define time and space discretizations
         x=np.linspace( -5, 5, 50)
-        t=np.linspace(0, 8*np.pi , 20) 
+        t=np.linspace(0, 8*np.pi , 20)
         dt=t[2]-t[1]
         X, T = np.meshgrid(x,t)
         # Create two patio-temporal patterns
@@ -158,13 +158,13 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         dmdf_gpu, dmdb_gpu, dmdv_gpu, dmdomega = linalg.dmd(a_gpu, k=2, modes='exact', return_amplitudes=True, return_vandermonde=True)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.cdmd(a_gpu, k=2, c=10, modes='exact', return_amplitudes=True, return_vandermonde=True)
-        assert np.allclose(dmdomega.get(), omega.get(), atol_float64)    
+        assert np.allclose(dmdomega.get(), omega.get(), atol_float64)
 
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_cdmd_complex64(self):
         # Define time and space discretizations
         x=np.linspace( -5, 5, 50)
-        t=np.linspace(0, 8*np.pi , 20) 
+        t=np.linspace(0, 8*np.pi , 20)
         dt=t[2]-t[1]
         X, T = np.meshgrid(x,t)
         # Create two patio-temporal patterns
@@ -175,13 +175,13 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         dmdf_gpu, dmdb_gpu, dmdv_gpu, dmdomega = linalg.dmd(a_gpu, k=2, modes='exact', return_amplitudes=True, return_vandermonde=True)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.cdmd(a_gpu, k=2, c=10, modes='exact', return_amplitudes=True, return_vandermonde=True)
-        assert np.allclose(dmdomega.get().real, omega.get().real, atol_float32)   
-        
+        assert np.allclose(dmdomega.get().real, omega.get().real, atol_float32)
+
     @skipUnless(linalg._has_cula, 'CULA required')
     def test_cdmd_complex128(self):
         # Define time and space discretizations
         x=np.linspace( -5, 5, 50)
-        t=np.linspace(0, 8*np.pi , 20) 
+        t=np.linspace(0, 8*np.pi , 20)
         dt=t[2]-t[1]
         X, T = np.meshgrid(x,t)
         # Create two patio-temporal patterns
@@ -192,8 +192,8 @@ class test_rlinalg(TestCase):
         a_gpu = gpuarray.to_gpu(a)
         dmdf_gpu, dmdb_gpu, dmdv_gpu, dmdomega = linalg.dmd(a_gpu, k=2, modes='exact', return_amplitudes=True, return_vandermonde=True)
         f_gpu, b_gpu, v_gpu, omega = rlinalg.cdmd(a_gpu, k=2, c=10, modes='exact', return_amplitudes=True, return_vandermonde=True)
-        assert np.allclose(dmdomega.get().real, omega.get().real, atol_float64)   
-        
+        assert np.allclose(dmdomega.get().real, omega.get().real, atol_float64)
+
 def suite():
     s = TestSuite()
     s.addTest(test_rlinalg('test_rsvd_float32'))
@@ -211,13 +211,13 @@ def suite():
     s.addTest(test_rlinalg('test_cdmd_float32'))
     s.addTest(test_rlinalg('test_cdmd_float64'))
     s.addTest(test_rlinalg('test_cdmd_complex64'))
-    s.addTest(test_rlinalg('test_cdmd_complex128'))   
-    
+    s.addTest(test_rlinalg('test_cdmd_complex128'))
+
     if misc.get_compute_capability(pycuda.autoinit.device) >= 1.3:
         s.addTest(test_rlinalg('test_rsvd_float32'))
         s.addTest(test_rlinalg('test_rsvd_float64'))
         s.addTest(test_rlinalg('test_rsvd_complex64'))
-        s.addTest(test_rlinalg('test_rsvd_complex128'))  
+        s.addTest(test_rlinalg('test_rsvd_complex128'))
         s.addTest(test_rlinalg('test_rsvdf_float32'))
         s.addTest(test_rlinalg('test_rsvdf_float64'))
         s.addTest(test_rlinalg('test_rsvdf_complex64'))
@@ -229,8 +229,8 @@ def suite():
         s.addTest(test_rlinalg('test_cdmd_float32'))
         s.addTest(test_rlinalg('test_cdmd_float64'))
         s.addTest(test_rlinalg('test_cdmd_complex64'))
-        s.addTest(test_rlinalg('test_cdmd_complex128')) 
-        
+        s.addTest(test_rlinalg('test_cdmd_complex128'))
+
     return s
 
 if __name__ == '__main__':


### PR DESCRIPTION
And found no error in your doc!

But sphinx-lint found trailing whitespaces, trailing tabs, so I cleaned them.

It also found a small python error in `docs/source/conf.py`: \u is a reserved escape sequence for unicode codepoints, so I used a raw-string instead:

```python
>>> "\usepackage{amsmath}"
  File "<stdin>", line 1
    "\usepackage{amsmath}"
                          ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-1: truncated \uXXXX escape
```

I don't know how it worked before? Maybe on old Python versions?

