### PR TITLE
Fix listing of numpy types during init

### DIFF
--- a/skcuda/misc.py
+++ b/skcuda/misc.py
@@ -634,7 +634,7 @@ diff.cache = {}
 
 
 # List of available numerical types provided by numpy:
-num_types = [np.sctypeDict[t] for t in \
+num_types = [np.sctypeDict[np.dtype(t).name] for t in \
              np.typecodes['AllInteger']+np.typecodes['AllFloat']]
 
 # Numbers of bytes occupied by each numerical type:


### PR DESCRIPTION
`np.sctypeDict` now requires the long name of the datatype, not the single-character name. This is a minimal change to fix this; the previous code would raise a `KeyError`.