### PR TITLE
Updates to maintain compatibility with modern Python versions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,11 +50,6 @@ for mod_name in MOCK_MODULES:
 import ctypes
 ctypes.cdll.LoadLibrary = Mock()
 
-# Prevent pkg_resources requirements checking from raising exceptions due to
-# missing dependencies:
-import pkg_resources
-pkg_resources.require = Mock()
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -26,7 +26,7 @@ Installation Dependencies
 ``scikit-cuda`` requires that the following software packages be
 installed:
 
-* `Python <http://www.python.org>`_ 2.7 or 3.4.
+* `Python <http://www.python.org>`_ 3.
 * `Setuptools <http://pythonhosted.org/setuptools>`_ 0.6c10 or later.
 * `Mako <http://www.makotemplates.org/>`_ 1.0.1 or later.
 * `NumPy <http://www.numpy.org>`_ 1.2.0 or later.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -29,10 +29,10 @@ installed:
 * `Python <http://www.python.org>`_ 3.
 * `Setuptools <http://pythonhosted.org/setuptools>`_ 0.6c10 or later.
 * `Mako <http://www.makotemplates.org/>`_ 1.0.1 or later.
-* `NumPy <http://www.numpy.org>`_ 1.2.0 or later.
-* `PyCUDA <http://mathema.tician.de/software/pycuda>`_ 2016.1 or later (some
+* `NumPy <https://numpy.org/>`_ 1.2.0 or later.
+* `PyCUDA <https://documen.tician.de/pycuda/>`_ 2016.1 or later (some
   parts of ``scikit-cuda`` might not work properly with earlier versions).
-* `NVIDIA CUDA Toolkit <http://www.nvidia.com/object/cuda_home_new.html>`_ 5.0
+* `NVIDIA CUDA Toolkit <https://docs.nvidia.com/cuda/index.html>`_ 5.0
   or later.
 
 Note that both Python and the CUDA Toolkit must be built for the same
@@ -43,7 +43,7 @@ are 64-bit.
 To run the unit tests, the following packages are also required:
 
 * `nose <https://nose.readthedocs.io/en/latest/>`_ 0.11 or later.
-* `SciPy <http://www.scipy.org>`_ 0.14.0 or later.
+* `SciPy <https://scipy.org/>`_ 0.14.0 or later.
 
 Some of the linear algebra functionality relies on the CULA toolkit;
 as of 2017, it is available to premium tier users of E.M. Photonics' HPC site
@@ -53,10 +53,10 @@ as of 2017, it is available to premium tier users of E.M. Photonics' HPC site
 
 To build the documentation, the following packages are also required:
 
-* `Docutils <http://docutils.sourceforge.net>`_ 0.5 or later.
-* `Jinja2 <http://jinja.pocoo.org>`_ 2.2 or later.
+* `Docutils <https://www.docutils.org/>`_ 0.5 or later.
+* `Jinja2 <https://jinja.palletsprojects.com/en/stable/>`_ 2.2 or later.
 * `Pygments <http://pygments.org>`_ 0.8 or later.
-* `Sphinx <http://sphinx.pocoo.org>`_ 1.0.1 or later.
+* `Sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ 1.0.1 or later.
 * `Sphinx ReadTheDocs Theme
   <https://github.com/snide/sphinx_rtd_theme>`_ 0.1.6 or later.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -42,7 +42,7 @@ are 64-bit.
 
 To run the unit tests, the following packages are also required:
 
-* `nose <http://code.google.com/p/python-nose/>`_ 0.11 or later.
+* `nose <https://nose.readthedocs.io/en/latest/>`_ 0.11 or later.
 * `SciPy <http://www.scipy.org>`_ 0.14.0 or later.
 
 Some of the linear algebra functionality relies on the CULA toolkit;

--- a/scikits/__init__.py
+++ b/scikits/__init__.py
@@ -1,5 +1,3 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development']
-NAMESPACE_PACKAGES = ['scikits']
 PACKAGES =           find_packages()
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -62,7 +61,6 @@ if __name__ == "__main__":
         description = DESCRIPTION,
         long_description = LONG_DESCRIPTION,
         url = URL,
-        namespace_packages = NAMESPACE_PACKAGES,
         packages = PACKAGES,
         include_package_data = True,
         install_requires = install_requires,

--- a/skcuda/__init__.py
+++ b/skcuda/__init__.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
 
 from .info import __doc__
 from .version import __version__

--- a/skcuda/utils.py
+++ b/skcuda/utils.py
@@ -55,9 +55,9 @@ except ImportError:
             raise RuntimeError('error executing {0}'.format(cmds))
 
         if sys.platform == 'darwin':
-            result = re.search('^\s@rpath/(lib.+.dylib)', out, re.MULTILINE)
+            result = re.search(r'^\s@rpath/(lib.+.dylib)', out, re.MULTILINE)
         else:
-            result = re.search('^\s+SONAME\s+(.+)$',out,re.MULTILINE)
+            result = re.search(r'^\s+SONAME\s+(.+)$', out, re.MULTILINE)
 
         if result:
             return result.group(1)

--- a/skcuda/version.py
+++ b/skcuda/version.py
@@ -1,2 +1,6 @@
-import pkg_resources
-__version__ = pkg_resources.require('scikit-cuda')[0].version
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("scikit-cuda")
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, py37
+envlist = py37, py38, py39, py310, py311, py312
 
 [testenv]
 deps = nose


### PR DESCRIPTION
The `pkg_resources` package no longer exists as part of the Python standard library. It has been officially [deprecated](https://setuptools.pypa.io/en/latest/deprecated/pkg_resources.html) for several years so this PR removes it and replaces it with equivalent functionality from other modules where needed.

Also includes a few other modernization updates here and there.